### PR TITLE
NEEDS TESTING: Possible fix for conda uploads

### DIFF
--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -74,7 +74,8 @@ def get_files(context, job_data):
     if 'conda' in build_targets:
         idx = build_targets.index('conda')
         conda_build_dir = context['conda_build_dir']
-        build_targets[idx] = os.path.join(conda_build_dir, '*.tar.bz2')
+        expected_files = '{}*.tar.bz2'.format(context["package"]["name"])
+        build_targets[idx] = os.path.join(conda_build_dir, expected_files)
 
     if 'pypi' in build_targets:
         idx = build_targets.index('pypi')


### PR DESCRIPTION
Currently this slurps everyting out of the build directory.  If an
existing package were to be left in there it would get pulled in by
accident.  Binstar checks this by only uploading packages that match the
provided name, but that causes failures if there's any other files in
the conda-bld directory.

This change tightens up the glob to only pull in changes that match the
package name.  I'm not sure if I'm accessing the data correctly as the
only documentation as to what `job_data` is that I can find is a test.
Assuming the test data is correct, this will work.

Note, this needs testing.  I'm working with @tpowellcio to get access to
a Windows box to verify this.