### PR TITLE
Fix submit on Windows

### DIFF
--- a/binstar_build_client/utils/filter.py
+++ b/binstar_build_client/utils/filter.py
@@ -10,13 +10,15 @@ class ExcludeGit(object):
         self.path = os.path.abspath(path)
         try:
             filelist = check_output(['git', 'ls-files'], cwd=self.path).decode().split()
-            self.to_include = [os.path.join(self.path, fn) for fn in filelist]
+            self.to_include = [ os.path.abspath(os.path.join(self.path, fn))
+                                for fn in filelist ]
         except CalledProcessError as err:
             self.to_include = None
 
         self.num_included = 0
 
     def __call__(self, filename):
+        filename = os.path.abspath(filename)
         if self.to_include is None:
             return False
 


### PR DESCRIPTION
submit did not work on Windows because git ls-files returns a list
of files where the path separator is '/'. The ExcludeGit class
excluded everything, because no paths matched any strings in the
to_include list.

This fixes the issue by canonicalising all paths with
os.path.abspath.