### PR TITLE
output build log to file, not to stdout

### DIFF
--- a/binstar_build_client/worker/worker.py
+++ b/binstar_build_client/worker/worker.py
@@ -19,6 +19,7 @@ from .utils.build_log import BuildLog
 from .utils.script_generator import gen_build_script, \
     EXIT_CODE_OK, EXIT_CODE_ERROR, EXIT_CODE_FAILED
 import inspect
+import subprocess as sp
 
 
 log = logging.getLogger('binstar.build')
@@ -289,7 +290,8 @@ class Worker(object):
         if self.args.show_new_procs:
             already_running_procs = get_my_procs()
 
-        p0 = BufferedPopen(args, stdout=build_log, iotimeout=iotimeout, cwd=working_dir)
+        p0 = BufferedPopen(args, stdout=build_log, iotimeout=iotimeout, cwd=working_dir, stdin=sp.PIPE)
+        p0.stdin.close()
 
         try:
             exit_code = p0.wait()


### PR DESCRIPTION
@mutirri this should help with navigating the output.  The build output will now be logged to a file instead of `stdout` thus `chalmers log binstar-build` this will help find errors in the binstar-bulid code quicker.