### PR TITLE
check for permission before rm_rf conda-bld dir

### DIFF
--- a/binstar_build_client/scripts/conda_clean_build_dir.py
+++ b/binstar_build_client/scripts/conda_clean_build_dir.py
@@ -18,13 +18,13 @@ def main():
     root_env = get_conda_root_prefix()
     build_root = os.path.join(root_env, 'conda-bld')
     has_access = os.access(build_root, os.W_OK)
-    if os.path.isdir(build_root) and has_access:
-        print("Removing conda build root %s" % build_root)
+    if not has_access:
+        build_root = os.path.join(os.path.expanduser('~'), 'conda-bld')
+    if os.path.isdir(build_root):
+        print("Removing conda build root {}".format(build_root))
         rm_rf(build_root)
     elif not os.path.isdir(build_root):
-        print("Conda build root %s does not exist" % build_root)
-    elif not has_access:
-        print("No access to remove build root %s" % build_root)
-
+        print("Conda build root {} does not exist".format(build_root))
+    
 if __name__ == '__main__':
     main()

--- a/binstar_build_client/scripts/conda_clean_build_dir.py
+++ b/binstar_build_client/scripts/conda_clean_build_dir.py
@@ -17,12 +17,14 @@ def main():
 
     root_env = get_conda_root_prefix()
     build_root = os.path.join(root_env, 'conda-bld')
-    if os.path.isdir(build_root):
+    has_access = os.access(build_root, os.W_OK)
+    if os.path.isdir(build_root) and has_access:
         print("Removing conda build root %s" % build_root)
         rm_rf(build_root)
-    else:
+    elif not os.path.isdir(build_root):
         print("Conda build root %s does not exist" % build_root)
-
+    elif not has_access:
+        print("No access to remove build root %s" % build_root)
 
 if __name__ == '__main__':
     main()

--- a/binstar_build_client/scripts/conda_clean_build_dir.py
+++ b/binstar_build_client/scripts/conda_clean_build_dir.py
@@ -23,7 +23,7 @@ def main():
     if os.path.isdir(build_root):
         print("Removing conda build root {}".format(build_root))
         rm_rf(build_root)
-    elif not os.path.isdir(build_root):
+    else:
         print("Conda build root {} does not exist".format(build_root))
     
 if __name__ == '__main__':


### PR DESCRIPTION
When working on PR #88 with a root python install and root user I found there could be an error message at the beginning of builds if a user lesser than root tried to run conda-clean-build-dir to delete ```os.path.join(get_conda_root_prefix(), 'conda-bld')```.   The error occurrred for lack of permissions to delete that directory.  

This PR changes the ```conda-clean-build-dir``` script to check for write permissions on that directory and not try to delete it if there is not permission to do so.