### PR TITLE
PR: --json, -j argument to anaconda worker register|list|deregister

### DIFF
--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -76,13 +76,14 @@ class Test(CLITestCase):
         self.assertEqual(loop.call_count, 1)
 
     def as_json_list(self):
-        out, err = sp.Popen(['anaconda', 'worker', 'list', '--json'],
+        out, err = sp.Popen(['anaconda', '--json-output', 'worker', 'list', ],
                 stdout=sp.PIPE, stderr=sp.PIPE).communicate()
         assert err == ''
-        try:
-            can_json_load = json.loads(out)
-        except:
-            can_json_load = False
+        for line in out.split('\n'):
+            try:
+                can_json_load = json.loads(line.rstrip())
+            except:
+                can_json_load = False
         self.assertTrue(can_json_load)
 
 if __name__ == '__main__':

--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -11,6 +11,7 @@ import os
 import yaml
 from mock import patch
 import unittest
+import subprocess as sp
 
 from binstar_client.tests.fixture import CLITestCase
 from binstar_client.tests.urlmock import urlpatch
@@ -74,6 +75,15 @@ class Test(CLITestCase):
         main(['--show-traceback', 'worker', 'run', worker_data['worker_id']], False)
         self.assertEqual(loop.call_count, 1)
 
+    def as_json_list(self):
+        out, err = sp.Popen(['anaconda', 'worker', 'list', '--json'],
+                stdout=sp.PIPE, stderr=sp.PIPE).communicate()
+        assert err == ''
+        try:
+            can_json_load = json.loads(out)
+        except:
+            can_json_load = False
+        self.assertTrue(can_json_load)
 
 if __name__ == '__main__':
     unittest.main()

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -228,7 +228,6 @@ class WorkerConfiguration(object):
         except Exception:
             if not as_json:
                 log.info('Failed on anaconda build deregister.\n')
-            self.print_registered_workers(as_json=as_json)
             if not as_json:
                 log.info('deregister failed with error:\n')
             else:

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -214,12 +214,14 @@ class WorkerConfiguration(object):
 
     def deregister(self, bs, as_json=False):
         'Deregister the worker from anaconda server'
-
         try:
 
-            removed_worker = bs.remove_worker(self.username, self.queue, self.worker_id)
+            removed_worker = bs.remove_worker(self.username,
+                                              self.queue,
+                                              self.worker_id)
             info = self.to_dict()
             info['deregistered'] = removed_worker
+            info = {'metadata': info}
             if not removed_worker:
                 info = (self.worker_id, self.username, self.queue,)
                 raise errors.BinstarError('Failed to remove_worker with argument of ' + \
@@ -231,11 +233,12 @@ class WorkerConfiguration(object):
 
                 log.info('Deregistered {0}',
                          self.worker_id,
-                         extra={'metadata': info})
+                         extra=info)
         except Exception:
+            failure_msg = 'deregister failed with error on worker_id {0}:'
             if not as_json:
                 info = {}
-            log.info('deregister failed with error on worker_id {0}:\n',
-                     self.worker_id, **info)
+                log.info(failure_msg.format(self.worker_id))
+            else:
+                log.info(failure_msg, self.worker_id, extra=info)
             raise
-

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -23,8 +23,7 @@ def main(args, context="worker"):
     wconfig.deregister(bs, as_json=args.json)
 
     os.unlink(wconfig.filename)
-    if not args.json:
-        log.debug("Removed worker config {}".format(wconfig.filename))
+    log.debug("Removed worker config {0}", wconfig.filename)
 
 
 def add_parser(subparsers, name='deregister',

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -17,10 +17,11 @@ def main(args, context="worker"):
     bs = get_binstar(args, cls=BinstarBuildAPI)
 
     wconfig = WorkerConfiguration.load(args.worker_id)
-    wconfig.deregister(bs)
+    wconfig.deregister(bs, as_json=args.json)
 
     os.unlink(wconfig.filename)
-    log.debug("Removed worker config {}".format(wconfig.filename))
+    if not args.json:
+        log.debug("Removed worker config {}".format(wconfig.filename))
 
 
 def add_parser(subparsers, name='deregister',
@@ -36,5 +37,8 @@ def add_parser(subparsers, name='deregister',
                         action='store_true')
     parser.add_argument('worker_id',
                         help="Worker id (required if no --config arg")
+    parser.add_argument('-j','--json',
+                        help="Output as json for machine reading",
+                        action="store_true")
     parser.set_defaults(main=default_func)
     return parser

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -13,9 +13,12 @@ from binstar_build_client.worker.register import WorkerConfiguration
 log = logging.getLogger('bisntar.build')
 
 def main(args, context="worker"):
-
+    if args.json:
+        old_log_level = args.log_level
+        args.log_level = -1
     bs = get_binstar(args, cls=BinstarBuildAPI)
-
+    if args.json:
+        args.log_level = old_log_level
     wconfig = WorkerConfiguration.load(args.worker_id)
     wconfig.deregister(bs, as_json=args.json)
 

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -13,18 +13,21 @@ from binstar_build_client.worker.register import WorkerConfiguration
 log = logging.getLogger('bisntar.build')
 
 def main(args, context="worker"):
-    if args.json:
+    if args.json_output:
         old_log_level = args.log_level
         args.log_level = -1
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    if args.json:
+    if args.json_output:
         args.log_level = old_log_level
     wconfig = WorkerConfiguration.load(args.worker_id)
-    wconfig.deregister(bs, as_json=args.json)
+    wconfig.deregister(bs, as_json=args.json_output)
 
     os.unlink(wconfig.filename)
-    log.debug("Removed worker config {0}", wconfig.filename)
-
+    msg = "Removed worker config {0}"
+    if args.json_output:
+        log.debug(msg, wconfig.filename)
+    else:
+        log.debug(msg.format(wconfig.filename))
 
 def add_parser(subparsers, name='deregister',
                description='Deregister a build worker to build jobs off of a binstar build queue',
@@ -39,8 +42,5 @@ def add_parser(subparsers, name='deregister',
                         action='store_true')
     parser.add_argument('worker_id',
                         help="Worker id (required if no --config arg")
-    parser.add_argument('-j','--json',
-                        help="Output as json for machine reading",
-                        action="store_true")
     parser.set_defaults(main=default_func)
     return parser

--- a/binstar_build_client/worker_commands/list.py
+++ b/binstar_build_client/worker_commands/list.py
@@ -14,7 +14,7 @@ log = logging.getLogger('binstar.build')
 
 def main(args):
 
-    WorkerConfiguration.print_registered_workers(as_json=args.json)
+    WorkerConfiguration.print_registered_workers(as_json=args.json_output)
 
 def add_parser(subparsers, name='list',
                description='List build workers and queues',
@@ -23,9 +23,6 @@ def add_parser(subparsers, name='list',
                                    help=description, description=description,
                                    epilog=epilog
                                    )
-    parser.add_argument('-j','--json',
-                        help="Output as json for machine reading.",
-                        action="store_true")
     parser.set_defaults(main=main)
 
     return parser

--- a/binstar_build_client/worker_commands/list.py
+++ b/binstar_build_client/worker_commands/list.py
@@ -14,7 +14,6 @@ log = logging.getLogger('binstar.build')
 
 def main(args):
 
-    log.info('Registered workers:\n')
     WorkerConfiguration.print_registered_workers(as_json=args.json)
 
 def add_parser(subparsers, name='list',

--- a/binstar_build_client/worker_commands/list.py
+++ b/binstar_build_client/worker_commands/list.py
@@ -14,8 +14,9 @@ log = logging.getLogger('binstar.build')
 
 def main(args):
 
-    log.info('Registered workers:\n')
-    WorkerConfiguration.print_registered_workers()
+    if not args.json:
+        log.info('Registered workers:\n')
+    WorkerConfiguration.print_registered_workers(as_json=args.json)
 
 def add_parser(subparsers, name='list',
                description='List build workers and queues',
@@ -24,6 +25,9 @@ def add_parser(subparsers, name='list',
                                    help=description, description=description,
                                    epilog=epilog
                                    )
+    parser.add_argument('-j','--json',
+                        help="Output as json for machine reading.",
+                        action="store_true")
     parser.set_defaults(main=main)
 
     return parser

--- a/binstar_build_client/worker_commands/list.py
+++ b/binstar_build_client/worker_commands/list.py
@@ -14,8 +14,7 @@ log = logging.getLogger('binstar.build')
 
 def main(args):
 
-    if not args.json:
-        log.info('Registered workers:\n')
+    log.info('Registered workers:\n')
     WorkerConfiguration.print_registered_workers(as_json=args.json)
 
 def add_parser(subparsers, name='list',

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -72,10 +72,18 @@ def main(args):
                                                  args.platform, args.hostname,
                                                  args.dist, as_json=args.json)
     worker_config.save()
-    log.info('Worker config saved at {0}.', worker_config.filename)
+    msg = 'Worker config saved at {0}.'
+    if args.json:
+        log.info(msg, worker_config.filename)
+    else:
+        log.info(msg.format(worker_config.filename))
     info = worker_config.to_dict()
     info['registered'] = True
-    log.info('Now run:\n\tanaconda worker run {0}', worker_config.worker_id)
+    msg = 'Now run:\n\tanaconda worker run {0}'
+    if args.json:
+        log.info(msg, worker_config.worker_id)
+    else:
+        log.info(msg.format(worker_config.worker_id))
 
 
 def add_parser(subparsers, name='register',

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -62,11 +62,13 @@ def main(args):
 
     args.username, args.queue = split_queue_arg(args.queue)
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    worker_config = WorkerConfiguration.register(bs, args.username, args.queue, args.platform, args.hostname, args.dist)
+    worker_config = WorkerConfiguration.register(bs, args.username, args.queue,
+                                                 args.platform, args.hostname,
+                                                 args.dist, as_json=args.json)
     worker_config.save()
-
-    log.info('Worker config saved at {}.'.format(worker_config.filename))
-    log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.worker_id))
+    if not args.json:
+        log.info('Worker config saved at {}.'.format(worker_config.filename))
+        log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.worker_id))
 
 
 def add_parser(subparsers, name='register',
@@ -91,6 +93,10 @@ def add_parser(subparsers, name='register',
 
     parser.add_argument('--dist', default=get_dist(),
                         help='The operating system distribution the worker should use (default: %(default)s)')
+
+    parser.add_argument('-j','--json',
+                        help="Output as json for machine reading.",
+                        action="store_true")
 
     parser.set_defaults(main=main)
 

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -61,26 +61,26 @@ def split_queue_arg(queue):
 def main(args):
 
     args.username, args.queue = split_queue_arg(args.queue)
-    if args.json:
+    if args.json_output:
         # avoid a print sys.stderr message from binstar
         old_log_level = args.log_level
         args.log_level = -1
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    if args.json:
+    if args.json_output:
         args.log_level = old_log_level
     worker_config = WorkerConfiguration.register(bs, args.username, args.queue,
                                                  args.platform, args.hostname,
-                                                 args.dist, as_json=args.json)
+                                                 args.dist, as_json=args.json_output)
     worker_config.save()
     msg = 'Worker config saved at {0}.'
-    if args.json:
+    if args.json_output:
         log.info(msg, worker_config.filename)
     else:
         log.info(msg.format(worker_config.filename))
     info = worker_config.to_dict()
     info['registered'] = True
     msg = 'Now run:\n\tanaconda worker run {0}'
-    if args.json:
+    if args.json_output:
         log.info(msg, worker_config.worker_id)
     else:
         log.info(msg.format(worker_config.worker_id))
@@ -108,10 +108,6 @@ def add_parser(subparsers, name='register',
 
     parser.add_argument('--dist', default=get_dist(),
                         help='The operating system distribution the worker should use (default: %(default)s)')
-
-    parser.add_argument('-j','--json',
-                        help="Output as json for machine reading.",
-                        action="store_true")
 
     parser.set_defaults(main=main)
 

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -61,7 +61,12 @@ def split_queue_arg(queue):
 def main(args):
 
     args.username, args.queue = split_queue_arg(args.queue)
+    if args.json:
+        old_log_level = args.log_level
+        args.log_level = -1
     bs = get_binstar(args, cls=BinstarBuildAPI)
+    if args.json:
+        args.log_level = old_log_level
     worker_config = WorkerConfiguration.register(bs, args.username, args.queue,
                                                  args.platform, args.hostname,
                                                  args.dist, as_json=args.json)

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -62,6 +62,7 @@ def main(args):
 
     args.username, args.queue = split_queue_arg(args.queue)
     if args.json:
+        # avoid a print sys.stderr message from binstar
         old_log_level = args.log_level
         args.log_level = -1
     bs = get_binstar(args, cls=BinstarBuildAPI)
@@ -71,9 +72,10 @@ def main(args):
                                                  args.platform, args.hostname,
                                                  args.dist, as_json=args.json)
     worker_config.save()
-    if not args.json:
-        log.info('Worker config saved at {}.'.format(worker_config.filename))
-        log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.worker_id))
+    log.info('Worker config saved at {0}.', worker_config.filename)
+    info = worker_config.to_dict()
+    info['registered'] = True
+    log.info('Now run:\n\tanaconda worker run {0}', worker_config.worker_id)
 
 
 def add_parser(subparsers, name='register',

--- a/binstar_build_client/worker_commands/run.py
+++ b/binstar_build_client/worker_commands/run.py
@@ -23,7 +23,7 @@ def main(args):
     worker_config = WorkerConfiguration.load(args.worker_id)
 
     args.conda_build_dir = args.conda_build_dir.format(platform=worker_config.platform)
-    log.info("Using conda build directory: {}".format(args.conda_build_dir))
+    log.info("Using conda build directory: {0}".format(args.conda_build_dir))
     log.info(str(worker_config))
     bs = get_binstar(args, cls=BinstarBuildAPI)
 

--- a/binstar_build_client/worker_commands/run.py
+++ b/binstar_build_client/worker_commands/run.py
@@ -25,7 +25,6 @@ def main(args):
     args.conda_build_dir = args.conda_build_dir.format(platform=worker_config.platform)
     log.info("Using conda build directory: {}".format(args.conda_build_dir))
     log.info(str(worker_config))
-
     bs = get_binstar(args, cls=BinstarBuildAPI)
 
     worker = Worker(bs, worker_config, args)


### PR DESCRIPTION
Fixes #123.  Output of the commands:

```
anaconda worker register|list|deregister
```
as json if including the --json flag.  This may help with automatic registration of workers or checking registration automatically.  Still when consuming the json output, it is necessary to iterate over the lines in sys.stdin and not try to json.loads the status message that comes out of get_binstar ('Using anaconda-server api site http://api.anaconda.org')