### PR TITLE
PR: new cli option: anaconda worker deregister all

### DIFF
--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -2,6 +2,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 
 import logging
 import os
+import platform
 
 from binstar_client import errors
 import yaml
@@ -69,8 +70,6 @@ class WorkerConfiguration(object):
     @classmethod
     def registered_workers(cls):
         "Iterate over the registered workers on this machine"
-
-        log.info('Registered workers:\n')
 
         for worker_id in os.listdir(cls.REGISTERED_WORKERS_DIR):
             if '.' not in worker_id:
@@ -218,3 +217,11 @@ class WorkerConfiguration(object):
             log.info('deregister failed with error:\n')
             raise
 
+    @classmethod
+    def deregister_all(cls, bs):
+
+        this_node = platform.node()
+        for worker in cls.registered_workers():
+            if worker.hostname == this_node:
+                worker.deregister(bs)
+                os.unlink(worker.filename)

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -196,7 +196,7 @@ class WorkerConfiguration(object):
             yaml.safe_dump(self.to_dict(), fd, default_flow_style=False)
 
 
-    def deregister(self, bs):
+    def deregister(self, bs, as_json=False):
         'Deregister the worker from anaconda server'
 
         try:
@@ -209,7 +209,9 @@ class WorkerConfiguration(object):
                                           'worker_id\t{}\tqueue\t{}/{}'.format(*info))
 
             log.info('Deregistered worker with worker-id {}'.format(self.worker_id))
-
+            os.unlink(self.filename)
+            msg = 'Removed worker config file {0}'
+            log.info(msg.format(self.filename))
         except Exception:
 
             log.info('Failed on anaconda build deregister.\n')
@@ -224,4 +226,3 @@ class WorkerConfiguration(object):
         for worker in cls.registered_workers():
             if worker.hostname == this_node:
                 worker.deregister(bs)
-                os.unlink(worker.filename)

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -222,7 +222,5 @@ class WorkerConfiguration(object):
     @classmethod
     def deregister_all(cls, bs):
 
-        this_node = platform.node()
         for worker in cls.registered_workers():
-            if worker.hostname == this_node:
-                worker.deregister(bs)
+            worker.deregister(bs)

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -2,25 +2,28 @@ from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 
 import os
-import yaml
 import logging
+import platform
+import yaml
+
 
 from binstar_client.utils import get_binstar
 
 from binstar_build_client import BinstarBuildAPI
 from binstar_build_client.worker.register import WorkerConfiguration
 
-log = logging.getLogger('bisntar.build')
+log = logging.getLogger('binstar.build')
 
 def main(args, context="worker"):
 
     bs = get_binstar(args, cls=BinstarBuildAPI)
-
-    wconfig = WorkerConfiguration.load(args.worker_id)
-    wconfig.deregister(bs)
-
-    os.unlink(wconfig.filename)
-    log.debug("Removed worker config {}".format(wconfig.filename))
+    if args.worker_id.lower() == 'all':
+        WorkerConfiguration.deregister_all(bs)
+    else:
+        wconfig = WorkerConfiguration.load(args.worker_id)
+        wconfig.deregister(bs)
+        os.unlink(wconfig.filename)
+        log.debug("Removed worker config {0}".format(wconfig.filename))
 
 
 def add_parser(subparsers, name='deregister',
@@ -31,10 +34,10 @@ def add_parser(subparsers, name='deregister',
     parser = subparsers.add_parser(name,
                                    help=description, description=description,
                                    epilog=epilog)
-    parser.add_argument('-l', '--list',
-                        help='List the workers registered by this user/machine and exit.',
-                        action='store_true')
     parser.add_argument('worker_id',
-                        help="Worker id (required if no --config arg")
+                        help="Worker id to deregister or \"all\" to " +\
+                             "deregister all workers registered by this " +\
+                             "hostname: {0}".format(platform.node()),
+                        )
     parser.set_defaults(main=default_func)
     return parser

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -14,15 +14,22 @@ from binstar_build_client.worker.register import WorkerConfiguration
 
 log = logging.getLogger('binstar.build')
 
+context_info = """Use one of:
+    anaconda worker deregister --all
+    anaconda worker deregister <some-worker-id>
+See also:
+    anaconda worker deregister -h
+"""
 def main(args, context="worker"):
 
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    if args.worker_id.lower() == 'all':
+    if args.all:
         WorkerConfiguration.deregister_all(bs)
-    else:
+    elif args.worker_id:
         wconfig = WorkerConfiguration.load(args.worker_id)
         wconfig.deregister(bs)
-
+    else:
+        log.info(context_info)
 
 def add_parser(subparsers, name='deregister',
                description='Deregister a build worker to build jobs off of a binstar build queue',
@@ -33,9 +40,11 @@ def add_parser(subparsers, name='deregister',
                                    help=description, description=description,
                                    epilog=epilog)
     parser.add_argument('worker_id',
-                        help="Worker id to deregister or \"all\" to " +\
-                             "deregister all workers registered by this " +\
-                             "hostname: {0}".format(platform.node()),
-                        )
+                        help="Worker id to deregister",
+                        nargs="?")
+    parser.add_argument('-a','--all',
+                        help="Deregister all workers " +\
+                             "registered by this hostname {}.".format(platform.node()),
+                        action="store_true")
     parser.set_defaults(main=default_func)
     return parser

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -22,8 +22,6 @@ def main(args, context="worker"):
     else:
         wconfig = WorkerConfiguration.load(args.worker_id)
         wconfig.deregister(bs)
-        os.unlink(wconfig.filename)
-        log.debug("Removed worker config {0}".format(wconfig.filename))
 
 
 def add_parser(subparsers, name='deregister',


### PR DESCRIPTION
Fixes #129.

Now use this command to deregister all workers whose hostname matches platform.node()
```
anaconda worker deregister all
```