### PR TITLE
Feature/worker name

### DIFF
--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -15,7 +15,6 @@ import unittest
 from binstar_client.tests.fixture import CLITestCase
 from binstar_client.tests.urlmock import urlpatch
 from binstar_build_client.scripts.worker import main
-from binstar_build_client.worker.worker import Worker
 from binstar_build_client.worker.register import WorkerConfiguration
 from glob import glob
 from binstar_client import errors
@@ -69,9 +68,9 @@ class Test(CLITestCase):
 
         self.assertEqual(loop.call_count, 0)
 
-        worker_config = WorkerConfiguration('worker_id', 'username', 'queue', 'platform', 'hostname', 'dist')
+        worker_config = WorkerConfiguration('worker_name', 'worker_id', 'username', 'queue', 'platform', 'hostname', 'dist')
         worker_config.save()
-        main(['--show-traceback', 'worker', 'run', worker_data['worker_id']], False)
+        main(['--show-traceback', 'worker', 'run', 'worker_name'], False)
         self.assertEqual(loop.call_count, 1)
 
 

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -128,6 +128,10 @@ class WorkerConfiguration(object):
                 os.unlink(dst)
 
 
+    @classmethod
+    def exists(cls, worker_name):
+        worker_file = os.path.join(cls.REGISTERED_WORKERS_DIR, worker_name)
+        return os.path.isfile(worker_file)
 
 
     @classmethod
@@ -182,6 +186,10 @@ class WorkerConfiguration(object):
         '''
         Register the worker with anaconda server
         '''
+        if name and cls.exists(name):
+            raise errors.Conflict("Worker with name {} already exists".format(name))
+
+
 
         worker_id = bs.register_worker(username, queue, platform, hostname, dist)
         log.info('Registered worker with worker_id:\t{}'.format(worker_id))

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -71,8 +71,6 @@ class WorkerConfiguration(object):
     def registered_workers(cls):
         "Iterate over the registered workers on this machine"
 
-        log.info('Registered workers:\n')
-
         for worker_name in os.listdir(cls.REGISTERED_WORKERS_DIR):
             if '.' not in worker_name:
                 yield cls.load(worker_name)
@@ -171,8 +169,12 @@ class WorkerConfiguration(object):
 
         has_workers = False
 
+        log.info('Registered workers:')
+
         for wconfig in cls.registered_workers():
-            msg = 'id: {worker_id} hostname: {hostname} queue: {username}/{queue}'.format(**wconfig.to_dict())
+            has_workers = True
+
+            msg = '{name}, id:{worker_id}, hostname:{hostname}, queue:{username}/{queue}'.format(name=wconfig.name, **wconfig.to_dict())
             if wconfig.pid:
                 msg += ' (running with pid: {})'.format(wconfig.pid)
 

--- a/binstar_build_client/worker/tests/test_jobs.py
+++ b/binstar_build_client/worker/tests/test_jobs.py
@@ -68,7 +68,10 @@ class MyWorker(Worker):
         args.show_new_procs = False
 
         worker_config = WorkerConfiguration(
-            'worker_id', 'username', 'queue', 'test_platform', 'test_hostname', 'dist')
+            'worker_name',
+            'worker_id', 'username', 'queue',
+            'test_platform', 'test_hostname', 'dist'
+        )
 
         self._working_dir = tempfile.mkdtemp()
         super(MyWorker, self).__init__(bs, worker_config, args)

--- a/binstar_build_client/worker/tests/test_worker.py
+++ b/binstar_build_client/worker/tests/test_worker.py
@@ -23,7 +23,10 @@ class MockWorker(Worker):
         args.timeout = 100
 
         worker_config = WorkerConfiguration(
-            'worker_id', 'username', 'queue', 'test_platform', 'test_hostname', 'dist')
+            'worker_name',
+            'worker_id', 'username', 'queue',
+            'test_platform', 'test_hostname', 'dist'
+        )
 
         Worker.__init__(self, bs, worker_config, args)
 

--- a/binstar_build_client/worker/tests/test_worker_config.py
+++ b/binstar_build_client/worker/tests/test_worker_config.py
@@ -25,7 +25,11 @@ class Test(unittest.TestCase):
 
     def test_str(self):
 
-        wc = WorkerConfiguration('worker_id', 'username', 'queue', 'platform', 'hostname', 'dist')
+        wc = WorkerConfiguration(
+            'worker_name',
+            'worker_id', 'username', 'queue',
+            'platform', 'hostname', 'dist'
+        )
 
         expected = """WorkerConfiguration
 \tpid: None
@@ -41,18 +45,27 @@ class Test(unittest.TestCase):
 
     def test_save_load(self):
 
-        wc = WorkerConfiguration('worker_id', 'username', 'queue', 'platform', 'hostname', 'dist')
+        wc = WorkerConfiguration(
+             'worker_name',
+             'worker_id', 'username', 'queue',
+             'platform', 'hostname', 'dist'
+        )
         wc.save()
 
         self.assertTrue(os.path.isfile(wc.filename))
 
-        wc2 = WorkerConfiguration.load('worker_id')
+        wc2 = WorkerConfiguration.load('worker_name')
 
         self.assertEqual(wc.to_dict(), wc2.to_dict())
 
     def test_running(self):
 
-        wc = WorkerConfiguration('worker_id', 'username', 'queue', 'platform', 'hostname', 'dist')
+        wc = WorkerConfiguration(
+             'worker_name',
+             'worker_id', 'username', 'queue',
+             'platform', 'hostname', 'dist'
+        )
+
         wc.save()
 
         self.assertFalse(wc.is_running())
@@ -65,7 +78,12 @@ class Test(unittest.TestCase):
 
     def test_already_running(self):
 
-        wc = WorkerConfiguration('worker_id', 'username', 'queue', 'platform', 'hostname', 'dist')
+        wc = WorkerConfiguration(
+            'worker_name',
+            'worker_id', 'username', 'queue',
+            'platform', 'hostname', 'dist'
+        )
+
         wc.save()
 
         self.assertFalse(wc.is_running())

--- a/binstar_build_client/worker_commands/list.py
+++ b/binstar_build_client/worker_commands/list.py
@@ -14,7 +14,7 @@ log = logging.getLogger('binstar.build')
 
 def main(args):
 
-    log.info('Registered workers:\n')
+#     log.info('Registered workers:\n')
     WorkerConfiguration.print_registered_workers()
 
 def add_parser(subparsers, name='list',

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -76,7 +76,7 @@ def main(args):
     worker_config.save()
 
     log.info('Worker config saved at {}.'.format(worker_config.filename))
-    log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.worker_name))
+    log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.name))
 
 
 def add_parser(subparsers, name='register',

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -70,13 +70,13 @@ def main(args):
     worker_config = WorkerConfiguration.register(
         bs, args.username, args.queue,
         args.platform, args.hostname, args.dist,
-        name=args.name
+        name=args.name,
     )
 
     worker_config.save()
 
     log.info('Worker config saved at {}.'.format(worker_config.filename))
-    log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.worker_id))
+    log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.worker_name))
 
 
 def add_parser(subparsers, name='register',

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -55,14 +55,24 @@ def split_queue_arg(queue):
     elif queue.count('-') == 2:
         _, username, queue = queue.split('-', 2)
     else:
-        raise errors.UserError("Build queue must be of the form build-USERNAME-QUEUENAME or USERNAME/QUEUENAME")
+        raise errors.UserError(
+            "Build queue must be of the form "
+            "build-USERNAME-QUEUENAME or USERNAME/QUEUENAME"
+        )
+
     return username, queue
 
 def main(args):
 
     args.username, args.queue = split_queue_arg(args.queue)
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    worker_config = WorkerConfiguration.register(bs, args.username, args.queue, args.platform, args.hostname, args.dist)
+
+    worker_config = WorkerConfiguration.register(
+        bs, args.username, args.queue,
+        args.platform, args.hostname, args.dist,
+        name=args.name
+    )
+
     worker_config.save()
 
     log.info('Worker config saved at {}.'.format(worker_config.filename))
@@ -82,6 +92,10 @@ def add_parser(subparsers, name='register',
     conda_platform = get_platform()
     parser.add_argument('queue', metavar='OWNER/QUEUE',
                         help='The queue to pull builds from')
+
+    parser.add_argument('-n', '--name', metavar='WORKER_NAME',
+                        help='Unique name of the worker')
+
     parser.add_argument('-p', '--platform',
                         default=conda_platform,
                         help='The platform this worker is running on (default: %(default)s)')


### PR DESCRIPTION
Name workers for cli usage. This should not break backwards compatibility.

This will help out with automating build deployment.

eg.
```
anaconda worker register sean/test-q -n test_worker_name

anaconda worker run test_worker_name
```

Worker names must be unique on a single host.
