### PR TITLE
Fix conda prefix lookup

### DIFF
--- a/binstar_build_client/utils/__init__.py
+++ b/binstar_build_client/utils/__init__.py
@@ -1,6 +1,7 @@
 
 
 import os
+import sys
 
 CONDA_EXE = 'conda.exe' if os.name == 'nt' else 'conda'
 
@@ -16,3 +17,4 @@ def get_conda_root_prefix():
             conda_exe_path = os.path.realpath(os.path.join(entry, 'conda'))
             bin_dir = os.path.dirname(conda_exe_path)
             return os.path.dirname(bin_dir)
+

--- a/binstar_build_client/utils/__init__.py
+++ b/binstar_build_client/utils/__init__.py
@@ -5,11 +5,14 @@ import os
 CONDA_EXE = 'conda.exe' if os.name == 'nt' else 'conda'
 
 def get_conda_root_prefix():
+    """
+    get the directory prefix to where conda is installed
+    """
+    canonical_dir_current_executable = os.path.dirname(os.path.realpath(sys.argv[0]))
+    paths = [canonical_dir_current_executable, ] + os.environ.get('PATH').split(os.pathsep)
 
-    for entry in os.environ.get('PATH').split(os.pathsep):
-
+    for entry in paths:
         if os.path.isdir(entry) and CONDA_EXE in os.listdir(entry):
             conda_exe_path = os.path.realpath(os.path.join(entry, 'conda'))
             bin_dir = os.path.dirname(conda_exe_path)
             return os.path.dirname(bin_dir)
-

--- a/binstar_build_client/utils/__init__.py
+++ b/binstar_build_client/utils/__init__.py
@@ -9,7 +9,7 @@ def get_conda_root_prefix():
     """
     get the directory prefix to where conda is installed
     """
-    canonical_dir_current_executable = os.path.dirname(os.path.realpath(sys.argv[0]))
+    canonical_dir_current_executable = os.path.dirname(os.path.realpath(sys.executable))
     paths = [canonical_dir_current_executable, ] + os.environ.get('PATH').split(os.pathsep)
 
     for entry in paths:

--- a/binstar_build_client/utils/tests/test_conda_root_preifx.py
+++ b/binstar_build_client/utils/tests/test_conda_root_preifx.py
@@ -18,7 +18,16 @@ class Test(unittest.TestCase):
     @mock.patch('os.path.isdir')
     @mock.patch('os.listdir')
     def test_finds_conda(self, listdir, isdir):
-        listdir.return_value = [CONDA_EXE, 'not_conda']
+
+        def list_dir(dirname):
+            print("dirname", dirname)
+            if dirname == '/a/bin':
+                return [CONDA_EXE, 'not_conda']
+            else:
+                return ['not_conda']
+
+        listdir.side_effect = list_dir
+
         prefix = get_conda_root_prefix()
         self.assertTrue(prefix in ('/a', "C:\\a"))
 

--- a/binstar_build_client/utils/tests/test_conda_root_preifx.py
+++ b/binstar_build_client/utils/tests/test_conda_root_preifx.py
@@ -1,8 +1,3 @@
-'''
-Created on Feb 12, 2015
-
-@author: sean
-'''
 import unittest
 import mock
 from binstar_build_client.utils import get_conda_root_prefix, CONDA_EXE
@@ -10,7 +5,9 @@ import os
 class Test(unittest.TestCase):
 
     @mock.patch.dict(os.environ, {'PATH': '/does_not_exist!!'})
-    def test_path_does_not_exist(self):
+    @mock.patch('os.listdir')
+    def test_path_does_not_exist(self, listdir):
+        listdir.return_value = []
         prefix = get_conda_root_prefix()
         self.assertIsNone(prefix)
 

--- a/binstar_build_client/worker_commands/run.py
+++ b/binstar_build_client/worker_commands/run.py
@@ -60,9 +60,13 @@ def add_parser(subparsers, name='run',
 
     dgroup = parser.add_argument_group('development options')
 
+    conda_prefix = get_conda_root_prefix()
+    if conda_prefix:
+        default_build_dir = os.path.join(conda_prefix, 'conda-bld', '{platform}')
+    else:
+        default_build_dir = None
     dgroup.add_argument("--conda-build-dir",
-                        default=os.path.join(get_conda_root_prefix(),
-                                             'conda-bld', '{platform}'),
+                        default=default_build_dir,
                         help="[Advanced] The conda build directory (default: %(default)s)",
                         )
 


### PR DESCRIPTION
Fixes Anaconda-Server/docs.anaconda.org#182

  * [x] Fix `get_conda_root_prefix` function to look up current executable prefix.
  * [x] Fix default argument to not join if prefix is none.