### PR TITLE
export the CONDA_NPY variable when numpy in engine

### DIFF
--- a/binstar_build_client/worker/tests/test_jobs.py
+++ b/binstar_build_client/worker/tests/test_jobs.py
@@ -1,8 +1,10 @@
 from __future__ import print_function, unicode_literals, absolute_import
 
+import copy
 import unittest
 from mock import Mock, patch
 import os
+import shutil
 import stat
 import requests
 
@@ -271,6 +273,14 @@ class Test(unittest.TestCase):
         with open(worker.build_logfile(job_data)) as fd:
             output = fd.read()
             self.assertMultiLineEqual(output, self.expected_output_iotimeout)
+
+    def test_auto_env_variables(self):
+
+        build_data = copy.deepcopy(default_build_data())
+        build_data['build_item_info']['engine'] = 'python=2.7 numpy=1.9 other_req=10'
+        exports = script_generator.create_exports(build_data)
+        self.assertEqual("19", exports['CONDA_NPY'])
+
 
 def have_docker():
     if os.environ.get('NO_DOCKER_TESTS'):

--- a/binstar_build_client/worker/utils/data/build_script.bat
+++ b/binstar_build_client/worker/utils/data/build_script.bat
@@ -233,7 +233,7 @@ goto:eof
     )
     if "%CONDA_NPY%" == "" (
 
-        python -c "import sys;import numpy;sys.stdout.write(''.join(numpy.__version__.split('.')[:2]))" || echo "" > %TEMP%\CONDA_NPY
+        conda list | findstr numpy & python -c "import sys;import numpy;sys.stdout.write(''.join(numpy.__version__.split('.')[:2]))"  > %TEMP%\CONDA_NPY || echo "" > %TEMP%\CONDA_NPY
         set /p CONDA_NPY=<%TEMP%\CONDA_NPY
 
     )

--- a/binstar_build_client/worker/utils/data/build_script.sh
+++ b/binstar_build_client/worker/utils/data/build_script.sh
@@ -107,7 +107,7 @@ setup_build(){
         export CONDA_PY=`python -c 'import sys; sys.stdout.write("{0}{1}".format(sys.version_info[0], sys.version_info[1]))'`
     fi
     if [ "$CONDA_NPY" == "" ];then
-        export CONDA_NPY=$(python -c "import sys;import numpy;sys.stdout.write(''.join(numpy.__version__.split('.')[:2]))" || echo "")
+        conda list | grep numpy && export CONDA_NPY=$(python -c "import sys;import numpy;sys.stdout.write(''.join(numpy.__version__.split('.')[:2]))") || export CONDA_NPY=""
     fi
     echo "CONDA_PY=$CONDA_PY"
     echo "CONDA_NPY=$CONDA_NPY"

--- a/binstar_build_client/worker/utils/data/build_script.sh
+++ b/binstar_build_client/worker/utils/data/build_script.sh
@@ -105,9 +105,11 @@ setup_build(){
     if ["$CONDA_PY" == ""]; then
         export CONDA_PY=`python -c 'import sys; sys.stdout.write("{0}{1}".format(sys.version_info[0], sys.version_info[1]))'`
     fi
-
+    if [ "$CONDA_NPY" == "" ];then
+        export CONDA_NPY=$(python -c "import sys;import numpy;sys.stdout.write(''.join(numpy.__version__.split('.')[:2]))" || echo "")
+    fi
     echo "CONDA_PY=$CONDA_PY"
-
+    echo "CONDA_NPY=$CONDA_NPY"
 }
 
 fetch_build_source(){

--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -117,11 +117,13 @@ def create_exports(build_data):
 
     api_site = build['api_endpoint']
     engine = build_item.get('engine')
+    CONDA_NPY = ''
     if 'numpy' in engine:
-        npy_version = engine.split('numpy=')[1].split()[0]
-        CONDA_NPY = "".join(npy_version.split('.')[:2])
-    else:
-        CONDA_NPY = ''
+        npy_version = engine.split('numpy')[1].split()
+        if npy_version:
+            CONDA_NPY = "".join(npy_version[0].split('.')[:2])
+            CONDA_NPY = CONDA_NPY.replace('=', '')
+
     exports = {
             # The build number as MAJOR.MINOR
             'BINSTAR_BUILD': build_item['build_no'],

--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -116,14 +116,19 @@ def create_exports(build_data):
     build = build_data['build_info']
 
     api_site = build['api_endpoint']
-
+    engine = build_item.get('engine')
+    if 'numpy' in engine:
+        npy_version = engine.split('numpy=')[1].split()[0]
+        CONDA_NPY = "".join(npy_version.split('.')[:2])
+    else:
+        CONDA_NPY = ''
     exports = {
             # The build number as MAJOR.MINOR
             'BINSTAR_BUILD': build_item['build_no'],
             'BINSTAR_BUILD_MAJOR': build['build_no'],
             'BINSTAR_BUILD_MINOR': build_item['sub_build_no'],
             # the engine from the engine tag
-            'BINSTAR_ENGINE': build_item.get('engine'),
+            'BINSTAR_ENGINE': engine,
             # the platform from the platform tag
             'BINSTAR_PLATFORM': build_item.get('platform', 'linux-64'),
             'BINSTAR_API_SITE': api_site,
@@ -133,6 +138,7 @@ def create_exports(build_data):
             'CONDA_BUILD_DIR': os.path.join(conda_root_prefix, 'conda-bld', build_item.get('platform', 'linux-64')),
             'BUILD_BASE': 'builds',
             'BUILD_ENV_DIR': 'build_envs',
+            'CONDA_NPY': CONDA_NPY,
            }
 
 


### PR DESCRIPTION
Refers to this #151 .  When numpy is in the engine in .binstar.yml, take the version and format it for the CONDA_NPY variable, e.g. CONDA_NPY=19 for numpy 1.9.