### PR TITLE
add list of regexes useful for redacting from build logs

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -20,3 +20,5 @@ script:
   - conda build conda.recipe
 
 build_targets: conda
+
+quiet: True

--- a/binstar_build_client/worker/tests/test_read_with_timeout.py
+++ b/binstar_build_client/worker/tests/test_read_with_timeout.py
@@ -2,9 +2,11 @@ import io
 import time
 import unittest
 
+
 import mock
 from binstar_build_client.worker.utils.timeout import read_with_timeout
 from threading import Event
+from binstar_build_client.worker.utils.process_wrappers import BuildProcess
 
 class MockProcess(object):
     def __init__(self, *args, **kwargs):
@@ -77,6 +79,14 @@ class TestReadWithTimeout(unittest.TestCase):
         read_with_timeout(p0, output, build_was_stopped_by_user=terminate)
         out = output.getvalue()
         self.assertIn(b'User requested', out)
+
+    def test_quiet(self):
+        cmd = ['echo', 'ncurses-5.9-1.   9% |##   | ETA:  0:00:00  76.02 MB/s']
+        p0 = BuildProcess(cmd, '.')
+        output = io.BytesIO()
+        read_with_timeout(p0, output, timeout=20, quiet=True)
+        out = output.getvalue()
+        self.assertEqual(b'', out)
 
 if __name__ == '__main__':
     unittest.main()

--- a/binstar_build_client/worker/tests/test_read_with_timeout.py
+++ b/binstar_build_client/worker/tests/test_read_with_timeout.py
@@ -83,7 +83,7 @@ class TestReadWithTimeout(unittest.TestCase):
 
     def test_quiet(self):
         for quiet in (True, False):
-            cmd = ['echo', 'ncurses-5.9-1.   9% |##   | ETA:  0:00:00  76.02 MB/s']
+            cmd = ['echo', 'ncurses-5.9-1.   9% |##   | ETA:  0:00:00  76.02 MB/s\r']
             if os.name == 'nt':
                 cmd = ['cmd.exe', '/c'] + cmd
             p0 = BuildProcess(cmd, '.')

--- a/binstar_build_client/worker/tests/test_read_with_timeout.py
+++ b/binstar_build_client/worker/tests/test_read_with_timeout.py
@@ -82,14 +82,18 @@ class TestReadWithTimeout(unittest.TestCase):
         self.assertIn(b'User requested', out)
 
     def test_quiet(self):
-        cmd = ['echo', 'ncurses-5.9-1.   9% |##   | ETA:  0:00:00  76.02 MB/s']
-        if os.name == 'nt':
-            cmd = ['cmd.exe', '/c'] + cmd
-        p0 = BuildProcess(cmd, '.')
-        output = io.BytesIO()
-        read_with_timeout(p0, output, timeout=20, quiet=True)
-        out = output.getvalue()
-        self.assertEqual(b'', out)
+        for quiet in (True, False):
+            cmd = ['echo', 'ncurses-5.9-1.   9% |##   | ETA:  0:00:00  76.02 MB/s']
+            if os.name == 'nt':
+                cmd = ['cmd.exe', '/c'] + cmd
+            p0 = BuildProcess(cmd, '.')
+            output = io.BytesIO()
+            read_with_timeout(p0, output, timeout=20, quiet=quiet)
+            out = output.getvalue()
+            if quiet:
+                self.assertEqual(b'', out)
+            else:
+                self.assertIn(b'ncurses', out)
 
 if __name__ == '__main__':
     unittest.main()

--- a/binstar_build_client/worker/tests/test_read_with_timeout.py
+++ b/binstar_build_client/worker/tests/test_read_with_timeout.py
@@ -1,4 +1,5 @@
 import io
+import os
 import time
 import unittest
 
@@ -82,6 +83,8 @@ class TestReadWithTimeout(unittest.TestCase):
 
     def test_quiet(self):
         cmd = ['echo', 'ncurses-5.9-1.   9% |##   | ETA:  0:00:00  76.02 MB/s']
+        if os.name == 'nt':
+            cmd = ['cmd.exe', '/c'] + cmd
         p0 = BuildProcess(cmd, '.')
         output = io.BytesIO()
         read_with_timeout(p0, output, timeout=20, quiet=True)

--- a/binstar_build_client/worker/utils/timeout.py
+++ b/binstar_build_client/worker/utils/timeout.py
@@ -1,9 +1,14 @@
 from threading import Event, Thread
-import time
 import logging
+import re
+import time
 
 log = logging.getLogger('binstar.build')
 
+
+QUIET_REGEXES = [
+    re.compile('(\|\s*#[#.\s]*\|\s*ETA)'),
+]
 
 class Timeout:
     """
@@ -55,7 +60,8 @@ def read_with_timeout(p0, output,
                       timeout=60 * 60,
                       iotimeout=60,
                       flush_iterval=10,
-                      build_was_stopped_by_user=lambda:None):
+                      build_was_stopped_by_user=lambda:None,
+                      quiet=False):
     """
     Read the stdout from a Popen object and wait for it to
     """
@@ -77,6 +83,11 @@ def read_with_timeout(p0, output,
         last_flush = time.time()
 
         while line:
+            if quiet:
+                while any(re.search(q, line) for q in QUIET_REGEXES):
+                    line = p0.readline()
+                    iotimer.tick()
+
             iotimer.tick()
 
             output.write(line)

--- a/binstar_build_client/worker/utils/timeout.py
+++ b/binstar_build_client/worker/utils/timeout.py
@@ -7,7 +7,7 @@ log = logging.getLogger('binstar.build')
 
 
 QUIET_REGEXES = [
-    re.compile('(\|\s*#[#.\s]*\|\s*ETA)'),
+    re.compile(b'(\|\s*#[#.\s]*\|\s*ETA)'),
 ]
 
 class Timeout:

--- a/binstar_build_client/worker/utils/timeout.py
+++ b/binstar_build_client/worker/utils/timeout.py
@@ -7,7 +7,7 @@ log = logging.getLogger('binstar.build')
 
 
 QUIET_REGEXES = [
-    re.compile(b'(\|\s*#[#.\s]*\|\s*ETA)'),
+    re.compile(b'\r$'),
 ]
 
 class Timeout:

--- a/binstar_build_client/worker/worker.py
+++ b/binstar_build_client/worker/worker.py
@@ -287,6 +287,7 @@ class Worker(object):
 
         elif build_filename:
             args.extend(['--build-tarball', build_filename])
+        quiet = build_data['build_item_info'].get('instructions',{}).get('quiet', False)
 
         log.info("Running command: (iotimeout={0})".format(iotimeout))
         log.info(" ".join(args))
@@ -308,7 +309,8 @@ class Worker(object):
                 timeout,
                 iotimeout,
                 BuildLog.INTERVAL,
-                build_was_stopped_by_user
+                build_was_stopped_by_user,
+                quiet
             )
         except BaseException:
             log.error(


### PR DESCRIPTION
Addresses #157, giving the ability to redact the progress bars from the build log.  

If ```quiet: True``` is given in the .binstar.yml for a package submission, the read_with_timeout function will now check each line against a list of regexes called QUIET_REGEXES to see if the line should be redacted from the build log.  Currently the only regex in QUIET_REGEXES is a one that matches patterns like:
```
ncurses-5.9-1.  22% |#######                        | ETA:  0:00:00 100.51 MB/s
```
