### PR TITLE
Use `build_targets.channels` to set upload channels

### DIFF
--- a/binstar_build_client/worker/tests/test_build_script.py
+++ b/binstar_build_client/worker/tests/test_build_script.py
@@ -163,6 +163,40 @@ class Test(unittest.TestCase):
                               ], output)
         p0.stdout.close()
 
+    def test_build_target_channels(self):
+        build_data = default_build_data()
+        build_data['build_item_info']['instructions']['build_targets'] = {
+            'files': 'output_file',
+            'channels': ['foo'],
+        }
+        script_filename = gen_build_script(tempfile.mkdtemp(),
+                                           build_data,
+                                           ignore_setup_build=True,
+                                           ignore_fetch_build_source=True)
+        self.addCleanup(os.unlink, script_filename)
+
+        with open(script_filename, 'r') as script_file:
+            script_content = script_file.read()
+
+        self.assertIn("--channel foo", script_content)
+
+    def test_build_channels(self):
+        build_data = default_build_data()
+        build_data['build_info']['channels'] = ['foo']
+        build_data['build_item_info']['instructions']['build_targets'] = {
+            'files': 'output_file',
+        }
+        script_filename = gen_build_script(tempfile.mkdtemp(),
+                                           build_data,
+                                           ignore_setup_build=True,
+                                           ignore_fetch_build_source=True)
+        self.addCleanup(os.unlink, script_filename)
+
+        with open(script_filename, 'r') as script_file:
+            script_content = script_file.read()
+
+        self.assertIn("--channel foo", script_content)
+
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.test_timeout']

--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -35,7 +35,7 @@ def get_channels(job_data):
     Return channel string to pass to binstar upload
     """
 
-    build_targets = job_data['build_item_info'].get('build_targets')
+    build_targets = job_data['build_item_info'].get('instructions', {}).get('build_targets')
 
     # TODO use git branch
     branch = 'dev'.replace('/', ':')


### PR DESCRIPTION
Issue #75 

To test:

* fork and clone http://github.com/Anaconda-server/testci
* add the following content to `.binstar.yml`: 
```
# Tell the build worker we want to upload the resulting conda package
build_targets:
  files: conda
  channels: [foo, bar]
```
* submit a build: `anaconda build submit .`

The resulting uploaded file should have the channels `foo` and `bar`.