### PR TITLE
move registered listing to query not files

### DIFF
--- a/binstar_build_client/mixins/build_queue.py
+++ b/binstar_build_client/mixins/build_queue.py
@@ -5,18 +5,19 @@ import binstar_build_client
 
 class BuildQueueMixin(object):
 
-    def register_worker(self, username, queue_name, platform, hostname, dist):
+    def register_worker(self, username, queue_name, platform, hostname, dist, name):
         url = '%s/build-worker/%s/%s' % (self.domain, username, queue_name)
         data, headers = jencode(platform=platform, hostname=hostname, dist=dist,
                                 binstar_version=binstar_client.__version__,
-                                binstar_build_version=binstar_build_client.__version__)
+                                binstar_build_version=binstar_build_client.__version__,
+                                name=name)
         res = self.session.post(url, data=data, headers=headers)
         self._check_response(res, [200])
         return res.json()['worker_id']
 
     def remove_worker(self, username, queue_name, worker_id):
         '''Un-register a worker
-        
+
         returns true if worker existed and was removed
         '''
 
@@ -27,7 +28,7 @@ class BuildQueueMixin(object):
 
     def pop_build_job(self, username, queue_name, worker_id):
         '''Un-register a worker
-        
+
         returns true if worker existed and was removed
         '''
 

--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -67,5 +67,22 @@ class Test(CLITestCase):
 
         self.assertEqual(loop.call_count, 1)
 
+    def test_register_backwards_compat(self):
+
+        worker_file = os.path.join(WorkerConfiguration.REGISTERED_WORKERS_DIR,
+                                   'worker_name_1')
+        worker_id = '123456789'
+        try:
+            with open(worker_file, 'w') as f:
+                f.write(yaml.safe_dump({'worker_id': worker_id}))
+            worker_id_to_name = WorkerConfiguration.backwards_compat_lookup()
+            self.assertIn(worker_id, worker_id_to_name)
+            self.assertEqual(worker_id_to_name[worker_id], 'worker_name_1')
+        finally:
+            if os.path.exists(worker_file):
+                os.unlink(worker_file)
+        worker_id_to_name = WorkerConfiguration.backwards_compat_lookup()
+        self.assertEqual(worker_id_to_name.get(worker_id, None), None)
+
 if __name__ == '__main__':
     unittest.main()

--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -34,6 +34,8 @@ class Test(CLITestCase):
     @classmethod
     def setUpClass(cls):
         WorkerConfiguration.REGISTERED_WORKERS_DIR = test_workers
+        if not os.path.exists(WorkerConfiguration.REGISTERED_WORKERS_DIR):
+            os.mkdir(WorkerConfiguration.REGISTERED_WORKERS_DIR)
         super(Test, cls).setUpClass()
 
     def tearDown(self):

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -174,8 +174,10 @@ class WorkerConfiguration(object):
         'Load a worker config from a worker_id'
         username = bs.user()['login']
         for worker in cls.registered_workers(bs):
+            log.info('worker {}'.format(repr(worker)))
             if worker_name == worker.worker_id or worker_name == worker.name:
-                return worker
+                if worker.hostname == cls.HOSTNAME:
+                    return worker
         raise errors.BinstarError('Worker with id '
                                   '{} not found'.format(worker_name))
     @classmethod

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -3,7 +3,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 import logging
 import os
 import platform
-import socket
+
 
 from binstar_client import errors
 import yaml
@@ -48,7 +48,7 @@ class InvalidWorkerConfigFile(errors.BinstarError):
 
 class WorkerConfiguration(object):
     REGISTERED_WORKERS_DIR = os.path.join(os.path.expanduser('~'), '.workers')
-    HOSTNAME = socket.gethostname()
+    HOSTNAME = platform.node()
     def __init__(self, name, worker_id, username, queue, platform, hostname, dist):
         self.name = name
         self.worker_id = worker_id
@@ -220,9 +220,8 @@ class WorkerConfiguration(object):
             removed_worker = bs.remove_worker(self.username, self.queue, self.worker_id)
 
             if not removed_worker:
-                info = (self.worker_id, self.queue,)
                 raise errors.BinstarError('Failed to remove_worker with argument of ' + \
-                                          'worker_id\t{}\tqueue\t{}'.format(*info))
+                                          'worker_id\t{}\tqueue\t{}'.format(self.worker_id, self.queue))
 
             log.info('Deregistered worker with worker-id {}'.format(self.worker_id))
         except Exception:

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -204,7 +204,10 @@ class WorkerConfiguration(object):
         '''
         Register the worker with anaconda server
         '''
-
+        for worker in cls.registered_workers(bs):
+            if worker.name == name:
+                raise errors.BinstarError('Cannot have duplicate worker '
+                                          '--name from same host: {}'.format(name))
         worker_id = bs.register_worker(username, queue, platform, hostname, dist,name=name)
         log.info('Registered worker with worker_id:\t{}'.format(worker_id))
 

--- a/binstar_build_client/worker/tests/test_worker_config.py
+++ b/binstar_build_client/worker/tests/test_worker_config.py
@@ -43,21 +43,6 @@ class Test(unittest.TestCase):
         self.assertEqual(str(wc), expected)
 
 
-    def test_save_load(self):
-
-        wc = WorkerConfiguration(
-             'worker_name',
-             'worker_id', 'username', 'queue',
-             'platform', 'hostname', 'dist'
-        )
-        wc.save()
-
-        self.assertTrue(os.path.isfile(wc.filename))
-
-        wc2 = WorkerConfiguration.load('worker_name')
-
-        self.assertEqual(wc.to_dict(), wc2.to_dict())
-
     def test_running(self):
 
         wc = WorkerConfiguration(
@@ -65,8 +50,6 @@ class Test(unittest.TestCase):
              'worker_id', 'username', 'queue',
              'platform', 'hostname', 'dist'
         )
-
-        wc.save()
 
         self.assertFalse(wc.is_running())
 
@@ -83,8 +66,6 @@ class Test(unittest.TestCase):
             'worker_id', 'username', 'queue',
             'platform', 'hostname', 'dist'
         )
-
-        wc.save()
 
         self.assertFalse(wc.is_running())
 

--- a/binstar_build_client/worker_commands/deregister.py
+++ b/binstar_build_client/worker_commands/deregister.py
@@ -26,7 +26,7 @@ def main(args, context="worker"):
     if args.all:
         WorkerConfiguration.deregister_all(bs)
     elif args.worker_id:
-        wconfig = WorkerConfiguration.load(args.worker_id)
+        wconfig = WorkerConfiguration.load(args.worker_id, bs)
         wconfig.deregister(bs)
     else:
         log.info(context_info)

--- a/binstar_build_client/worker_commands/docker_run.py
+++ b/binstar_build_client/worker_commands/docker_run.py
@@ -29,9 +29,9 @@ def main(args):
                                "Run:\n\tpip install docker-py")
 
 
-    worker_config = WorkerConfiguration.load(args.worker_id)
-
     bs = get_binstar(args, cls=BinstarBuildAPI)
+    username = bs.user()['login']
+    worker_config = WorkerConfiguration.load(args.worker_id, bs, username)
 
     worker = DockerWorker(bs, worker_config, args)
     worker.work_forever()

--- a/binstar_build_client/worker_commands/list.py
+++ b/binstar_build_client/worker_commands/list.py
@@ -7,6 +7,8 @@ from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 
 from binstar_build_client.worker.register import WorkerConfiguration
+from binstar_client.utils import get_binstar
+from binstar_build_client import BinstarBuildAPI
 
 import logging
 log = logging.getLogger('binstar.build')
@@ -14,8 +16,8 @@ log = logging.getLogger('binstar.build')
 
 def main(args):
 
-#     log.info('Registered workers:\n')
-    WorkerConfiguration.print_registered_workers()
+    bs = get_binstar(args, cls=BinstarBuildAPI)
+    WorkerConfiguration.print_registered_workers(bs)
 
 def add_parser(subparsers, name='list',
                description='List build workers and queues',

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -58,7 +58,7 @@ def main(args):
         name=args.name,
     )
 
-    log.info('Worker config saved at {}.'.format(worker_config.filename))
+    log.info('When running, worker PID files will be at {}.<PID>.'.format(worker_config.filename))
     log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.name))
 
 

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -13,7 +13,8 @@ from binstar_client import errors
 from binstar_client.utils import get_binstar
 
 from binstar_build_client import BinstarBuildAPI
-from binstar_build_client.worker.register import WorkerConfiguration
+from binstar_build_client.worker.register import (WorkerConfiguration,
+                                                  split_queue_arg)
 
 OS_MAP = {'darwin': 'osx', 'windows':'win'}
 ARCH_MAP = {'x86': '32',
@@ -45,22 +46,6 @@ def get_dist():
         return platform.win32_ver()[0].lower()
     return 'unknown'
 
-def split_queue_arg(queue):
-    '''
-    Support old and new style queue
-    '''
-
-    if queue.count('/') == 1:
-        username, queue = queue.split('/', 1)
-    elif queue.count('-') == 2:
-        _, username, queue = queue.split('-', 2)
-    else:
-        raise errors.UserError(
-            "Build queue must be of the form "
-            "build-USERNAME-QUEUENAME or USERNAME/QUEUENAME"
-        )
-
-    return username, queue
 
 def main(args):
 
@@ -72,8 +57,6 @@ def main(args):
         args.platform, args.hostname, args.dist,
         name=args.name,
     )
-
-    worker_config.save()
 
     log.info('Worker config saved at {}.'.format(worker_config.filename))
     log.info('Now run:\n\tanaconda worker run {}'.format(worker_config.name))

--- a/binstar_build_client/worker_commands/run.py
+++ b/binstar_build_client/worker_commands/run.py
@@ -20,13 +20,11 @@ log = logging.getLogger('binstar.build')
 
 
 def main(args):
-    worker_config = WorkerConfiguration.load(args.worker_id)
-
+    bs = get_binstar(args, cls=BinstarBuildAPI)
+    worker_config = WorkerConfiguration.load(args.worker_id, bs)
     args.conda_build_dir = args.conda_build_dir.format(platform=worker_config.platform)
     log.info("Using conda build directory: {}".format(args.conda_build_dir))
     log.info(str(worker_config))
-
-    bs = get_binstar(args, cls=BinstarBuildAPI)
 
     worker = Worker(bs, worker_config, args)
 


### PR DESCRIPTION
Gets rid of the need for files in ~/.workers to track registered workers.

Still failing unittests