### PR TITLE
secondary timeout around readline to allow subprocess.poll

### DIFF
--- a/binstar_build_client/worker/utils/timeout.py
+++ b/binstar_build_client/worker/utils/timeout.py
@@ -99,7 +99,6 @@ def read_with_timeout(p0, output,
             log.debug("Wait for line ...")
             lines = []
             while not lines:
-                start = time.time()
                 t = Thread(target=readline_timeout, args=(lines,))
                 t.start()
                 repeats = 0


### PR DESCRIPTION
In testing PR #88 I found an issue of successful builds hanging while trying to read a final line of stdout that did not exist (hanging on p0.readline in ```read_with_timeout```).  This PR places that blocking readline call within a thread, so that the process return code can be periodically polled.