### PR TITLE
PR: allow use of envvars or env in .binstar.yml for environment vars

### DIFF
--- a/binstar_build_client/build_commands/info.py
+++ b/binstar_build_client/build_commands/info.py
@@ -62,12 +62,12 @@ def list_builds(args):
 
     log.info('Getting builds:')
 
-    fmt = '%(build_no)15s | %(status)15s | %(platform)15s | %(engine)15s | %(env)15s'
+    fmt = '%(build_no)15s | %(status)15s | %(platform)15s | %(engine)15s | %(envvars)15s'
 
     header = {'build_no':'Build #', 'status':'Status',
               'platform':'Platform',
               'engine':'Engine',
-              'env':'Env',
+              'envvars':'Env',
               }
 
     log.info(fmt % header)

--- a/binstar_build_client/build_commands/info.py
+++ b/binstar_build_client/build_commands/info.py
@@ -69,7 +69,6 @@ def list_builds(args):
               'engine':'Engine',
               'envvars':'Env',
               }
-
     log.info(fmt % header)
 
     log.info(fmt.replace('|', '+') % dict.fromkeys(header, '-' * 15))
@@ -77,6 +76,8 @@ def list_builds(args):
         for item in build['items']:
             item.setdefault('status', build.get('status', '?'))
             item['build_no'] = '%s.%s' % (build['build_no'], item['sub_build_no'])
+            if not 'envvars' in item:
+                item['envvars'] = header.get('env', '')
             log.info(fmt % item)
     log.info('')
     return
@@ -87,7 +88,6 @@ def add_parser(subparsers):
                                       help='Tail the build output of build number X.Y',
                                       description=__doc__,
                                       )
-
     parser.add_argument('package', metavar='OWNER/PACKAGE',
                        help='build to the package OWNER/PACKAGE',
                        type=package_specs)
@@ -113,6 +113,7 @@ def add_parser(subparsers):
                                       help='list the builds for package',
                                       description=__doc__,
                                       )
+
     parser.add_argument('package', metavar='OWNER/PACKAGE',
                        help='build to the package OWNER/PACKAGE',
                        nargs='?',

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -54,7 +54,10 @@ def submit_build(binstar, args):
         build_matrix = list(yaml.load_all(cfg))
 
     builds = list(serialize_builds(build_matrix))
-
+    for build in builds:
+        if build.get('envvars'):
+            # Note: backwards compat for a while
+            build['env'] = build['envvars']
     if args.platform:
 
         log.info("Only selecting builds on platform %s" % args.platform)
@@ -136,6 +139,9 @@ def submit_git_build(binstar, args):
     if not args.dry_run:
         log.info("Submitting the following repo for package creation: %s" % args.git_url)
         builds = get_gitrepo(urlparse(args.path))
+        for build in builds:
+            if build.get('envvars'):
+                build['env'] = build['envvars']
         # TODO: change channels= to labels=
         build = binstar.submit_for_url_build(args.package.user, args.package.name, builds,
                                              channels=args.labels, queue=args.queue, sub_dir=args.sub_dir,
@@ -182,7 +188,6 @@ def main(args):
                     package_name = build.get('package')
                 if build.get('user'):
                     user_name = build.get('user')
-
         # Force package to exist
         if args.package:
             if user_name and not args.package.user == user_name:

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -3,7 +3,7 @@ Build command
 
 Submit a build from your local path or  via a git url:
 
-See also: 
+See also:
 
   * [Submit A Build](http://docs.anaconda.org/build.html#SubmitABuild)
   * [Submit A Build From Github](http://docs.anaconda.org/build.html#GithubBuilds)
@@ -68,7 +68,7 @@ def submit_build(binstar, args):
 
     log.info('Submitting %i sub builds' % len(builds))
     for i, build in enumerate(builds):
-        log.info(' %i)' % i + ' %(platform)-10s  %(engine)-15s  %(env)-15s' % build)
+        log.info(' %i)' % i + ' %(platform)-10s  %(engine)-15s  %(envvars)-15s' % build)
 
     if not args.dry_run:
         if args.git_url:

--- a/binstar_build_client/utils/matrix.py
+++ b/binstar_build_client/utils/matrix.py
@@ -15,21 +15,22 @@ def expand_build_matrix(instruction_set):
 
     platforms = instruction_set.pop('platform', ['linux-64']) or [None]
     if not isinstance(platforms, list): platforms = [platforms]
-    envs = instruction_set.pop('env', [None]) or [None]
+    envs = instruction_set.pop('envvars',
+              instruction_set.pop('env', [None])) or [None]
     if not isinstance(envs, list): envs = [envs]
     engines = instruction_set.pop('engine', ['python=2']) or [None]
     if not isinstance(engines, list): engines = [engines]
 
     for platform, env, engine in product(platforms, envs, engines):
         build = instruction_set.copy()
-        build.update(platform=platform, env=env, engine=engine)
+        build.update(platform=platform, envvars=env, engine=engine)
         yield build
 
 def serialize_builds(instruction_sets):
     builds = {}
     for instruction_set in instruction_sets:
         for build in expand_build_matrix(instruction_set):
-            k = '%s::%s::%s' % (build['platform'], build['engine'], build['env'])
+            k = '%s::%s::%s' % (build['platform'], build['engine'], build.get('envvars', build.get('env')))
             bld = builds.setdefault(k, build)
             bld.update(build)
 

--- a/binstar_build_client/worker/tests/test_build_script.py
+++ b/binstar_build_client/worker/tests/test_build_script.py
@@ -163,6 +163,19 @@ class Test(unittest.TestCase):
                               ], output)
         p0.stdout.close()
 
+    def test_env_envvars(self):
+        'Test env or envvars can be used in .binstar.yml'
+        build_data = default_build_data()
+        for name in ('env', 'envvars'):
+            build_data['build_item_info'][name] = {'ENVIRONMENT_VARIABLE': '1'}
+            script_filename = gen_build_script(tempfile.mkdtemp(),
+                                               build_data,
+                                               ignore_setup_build=True,
+                                               ignore_fetch_build_source=True)
+            self.addCleanup(os.unlink, script_filename)
+            contents = open(script_filename).read()
+            self.assertIn('ENVIRONMENT_VARIABLE=', contents)
+            build_data['build_item_info'].pop(name)
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.test_timeout']

--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -146,8 +146,7 @@ def create_exports(build_data):
             'CONDA_NPY': CONDA_NPY,
            }
 
-
-    build_env = build_item.get('env')
+    build_env = build_item.get('envvars', build_item.get('env', {}))
     if isinstance(build_env, (str, unicode)):
         _build_env = {}
         for item in shlex.split(build_env):
@@ -159,7 +158,6 @@ def create_exports(build_data):
 
     if isinstance(build_env, dict):
         exports.update(build_env)
-
     return exports
 
 #===============================================================================


### PR DESCRIPTION
This PR addresses issue #135 to have a better name than ```env``` for environment variables in ```.binstar.yml```.  Now ```envvars``` or ```env``` can be used in .binstar.yml like:

```
envvars:
 - VARIABLE1=abc
 - VARIABLE1=def
```

