### PR TITLE
avoid confusion related to use of pwd or %CD% in build scripts

### DIFF
--- a/binstar_build_client/worker/tests/test_jobs.py
+++ b/binstar_build_client/worker/tests/test_jobs.py
@@ -281,8 +281,13 @@ class Test(unittest.TestCase):
 
         build_data = copy.deepcopy(default_build_data())
         build_data['build_item_info']['engine'] = 'python=2.7 numpy=1.9 other_req=10'
-        exports = script_generator.create_exports(build_data)
+        exports = script_generator.create_exports(build_data, '.')
         self.assertEqual("19", exports['CONDA_NPY'])
+
+    def test_working_dir(self):
+        build_data = copy.deepcopy(default_build_data())
+        exports = script_generator.create_exports(build_data, '/some/dir')
+        self.assertEqual(exports['WORKING_DIR'], '/some/dir')
 
     def test_install_channels(self):
         working_dir = tempfile.mkdtemp()

--- a/binstar_build_client/worker/utils/data/build_script.bat
+++ b/binstar_build_client/worker/utils/data/build_script.bat
@@ -114,7 +114,7 @@ goto:eof
 
 :fetch_build_source
 
-    set "SOURCE_DIR=%CD%\source"
+    set "SOURCE_DIR=%WORKING_DIR%\source"
 
     @echo off
 
@@ -181,7 +181,7 @@ goto:eof
 
 
     :: Make BUILD_ENV_PATH an absolute path
-    set "BUILD_ENV_PATH=%CD%\env"
+    set "BUILD_ENV_PATH=%WORKING_DIR%\env"
 
     echo [Setting engine]
 
@@ -195,7 +195,7 @@ goto:eof
     conda clean --lock
 
 
-    set "CONDARC=%CD%\condarc"
+    set "CONDARC=%WORKING_DIR%\condarc"
 
     :: Touch file
     touch "%CONDARC%"

--- a/binstar_build_client/worker/utils/data/build_script.sh
+++ b/binstar_build_client/worker/utils/data/build_script.sh
@@ -65,7 +65,7 @@ export {{key}}={{quote(value)}}
 setup_build(){
 
 
-    export BUILD_ENV_PATH=`pwd`"/env"
+    export BUILD_ENV_PATH="%{WORKING_DIR}/env"
 
     echo -e "\n[Setup Build]"
 
@@ -81,7 +81,7 @@ setup_build(){
     echo "conda clean --lock"
     conda clean --lock
 
-    export CONDARC=`pwd`/"condarc"
+    export CONDARC="${WORKING_DIR}/condarc"
 
     echo "export CONDARC=$CONDARC"
     touch "$CONDARC"
@@ -118,7 +118,7 @@ fetch_build_source(){
 
     echo -e '\n[Fetching Build Source]'
 
-    SOURCE_DIR=`pwd`"/source"
+    SOURCE_DIR="${WORKING_DIR}/source"
     echo "SOURCE_DIR=$SOURCE_DIR"
 
     rm -rf "$SOURCE_DIR"

--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -109,7 +109,7 @@ def create_git_context(build):
         git_info['commit'] = github_info['after']
     return git_info
 
-def create_exports(build_data):
+def create_exports(build_data, working_dir):
     """
     Create a dict of environment variables for the build script
     """
@@ -141,8 +141,7 @@ def create_exports(build_data):
             'BINSTAR_PACKAGE': build_data['package']['name'],
             'BINSTAR_BUILD_ID': build['_id'],
             'CONDA_BUILD_DIR': os.path.join(conda_root_prefix, 'conda-bld', build_item.get('platform', 'linux-64')),
-            'BUILD_BASE': 'builds',
-            'BUILD_ENV_DIR': 'build_envs',
+            'WORKING_DIR': working_dir,
             'CONDA_NPY': CONDA_NPY,
            }
 
@@ -186,7 +185,7 @@ def gen_build_script(working_dir, build_data, **context):
         script_filename = os.path.join(working_dir, 'build_script.sh')
 
 
-    exports = create_exports(build_data)
+    exports = create_exports(build_data, working_dir)
     instructions = build_data['build_item_info'].get('instructions', {})
     install_channels = instructions.get('install_channels', None) or ['defaults']
     if not 'defaults' in install_channels:


### PR DESCRIPTION
Fixes #180 

Pass in the WORKING_DIR to the build script rather than using `pwd` (posix) or `%CD%` (Windows)