### PR TITLE
Fix unit-test for CONDA_NPY environment variable

### DIFF
--- a/binstar_build_client/worker/tests/test_build_script.py
+++ b/binstar_build_client/worker/tests/test_build_script.py
@@ -222,6 +222,7 @@ class Test(unittest.TestCase):
 
     def test_conda_npy(self):
         build_data = default_build_data()
+        build_data['build_item_info']['engine'] = 'numpy=1.9'
 
         script_filename = gen_build_script(tempfile.mkdtemp(),
                                            build_data,
@@ -236,18 +237,8 @@ class Test(unittest.TestCase):
         conda_npy = [line for line in lines if "CONDA_NPY" in line]
         self.assertTrue(len(conda_npy) > 0)
         conda_npy_read = conda_npy[0].strip().replace('CONDA_NPY=', '')
-        try:
-            import numpy
-            has_numpy = True
-            conda_npy = "".join(numpy.__version__.split('.')[:2])
-        except ImportError:
-            has_numpy = False
+        self.assertEqual(conda_npy_read, '19')
 
-        if not conda_npy_read:
-            self.assertFalse(has_numpy)
-        else:
-            self.assertTrue(has_numpy)
-            self.assertEqual(conda_npy, conda_npy_read)
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.test_timeout']


### PR DESCRIPTION
@PeterDSteinberg 

Because the build creates its own build environment, `import numpy` doesn't mean that it shows up in the build script `CONDA_NPY`.