### PR TITLE
important fixes for docker and docker tests 

### DIFF
--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -9,7 +9,7 @@ from __future__ import (print_function, unicode_literals, division,
 
 import os
 import yaml
-from mock import patch
+from mock import patch, Mock
 import unittest
 
 from binstar_client.tests.fixture import CLITestCase
@@ -64,6 +64,19 @@ class Test(CLITestCase):
     def test_worker_simple(self, run, load, loop, urls):
 
         main(['--show-traceback', 'worker', 'run', worker_data['worker_id']], False)
+
+        self.assertEqual(loop.call_count, 1)
+
+    @urlpatch
+    @patch('binstar_build_client.worker.docker_worker.DockerWorker.work_forever')
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.load')
+    @patch('binstar_build_client.worker.docker_worker.DockerWorker.run')
+    @patch('binstar_build_client.worker_commands.docker_run.docker')
+    @patch('binstar_build_client.worker.docker_worker.docker')
+    def test_worker_simple_docker(self, docker1, docker2, run, load, loop, urls):
+        docker1.Client = docker2.Client = Mock()
+
+        main(['--show-traceback', 'worker', 'docker_run', worker_data['worker_id']], False)
 
         self.assertEqual(loop.call_count, 1)
 

--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -73,7 +73,9 @@ class Test(CLITestCase):
     @patch('binstar_build_client.worker.docker_worker.DockerWorker.run')
     @patch('binstar_build_client.worker_commands.docker_run.docker')
     @patch('binstar_build_client.worker.docker_worker.docker')
-    def test_worker_simple_docker(self, docker1, docker2, run, load, loop, urls):
+    @patch('binstar_build_client.worker.docker_worker.kwargs_from_env')
+    def test_worker_simple_docker(self, kwargs_from_env, docker1, docker2, run, load, loop, urls):
+
         docker1.Client = docker2.Client = Mock()
 
         main(['--show-traceback', 'worker', 'docker_run', worker_data['worker_id']], False)

--- a/binstar_build_client/worker/docker_worker.py
+++ b/binstar_build_client/worker/docker_worker.py
@@ -21,6 +21,7 @@ try:
     from docker.utils import kwargs_from_env
 except ImportError:
     docker = None
+    kwargs_from_env = None
 
 class DockerWorker(Worker):
     """

--- a/binstar_build_client/worker/tests/test_jobs.py
+++ b/binstar_build_client/worker/tests/test_jobs.py
@@ -363,7 +363,8 @@ class TestDockerWorker(DockerWorker):
         args.image = 'binstar/linux-64'
 
         worker_config = WorkerConfiguration(
-            'worker_id', 'username', 'queue', 'test_platform', 'test_hostname', 'dist')
+            'worker_id', 'worker_id', 'username', 'queue', 'test_platform',
+            'test_hostname', 'dist')
 
         super(TestDockerWorker, self).__init__(bs, worker_config, args)
 

--- a/binstar_build_client/worker_commands/docker_run.py
+++ b/binstar_build_client/worker_commands/docker_run.py
@@ -30,9 +30,7 @@ def main(args):
 
 
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    username = bs.user()['login']
-    worker_config = WorkerConfiguration.load(args.worker_id, bs, username)
-
+    worker_config = WorkerConfiguration.load(args.worker_id, bs)
     worker = DockerWorker(bs, worker_config, args)
     worker.work_forever()
 


### PR DESCRIPTION
There were some regression bugs resulting from refactoring the worker registration from file in ~/.workers to anaconda-server query.  One bug was an extra argument to a function in docker_run.