### PR TITLE
Feature/envvars2

### DIFF
--- a/binstar_build_client/build_commands/_build.py
+++ b/binstar_build_client/build_commands/_build.py
@@ -114,7 +114,7 @@ def expand_build_matrix(instruction_set):
 
     platforms = instruction_set.pop('platform', ['linux-64']) or [None]
     if not isinstance(platforms, list): platforms = [platforms]
-    envs = instruction_set.pop('env', [None]) or [None]
+    envs = instruction_set.pop('envvars', instruction_set.pop('env', [None])) or [None]
     if not isinstance(envs, list): envs = [envs]
     engines = instruction_set.pop('engine', ['python=2']) or [None]
     if not isinstance(engines, list): engines = [engines]

--- a/binstar_build_client/build_commands/_build.py
+++ b/binstar_build_client/build_commands/_build.py
@@ -219,7 +219,7 @@ def main(args):
     if not isfile(binstar_yml):
         raise UserError("file %s does not exist" % binstar_yml)
 
-    build_matrix = load_all_binstar_yml()
+    build_matrix = load_all_binstar_yml(args.path)
     for build in build_matrix:
         package_name = build.get('package')
         user_name = build.get('user')

--- a/binstar_build_client/build_commands/_build.py
+++ b/binstar_build_client/build_commands/_build.py
@@ -146,7 +146,8 @@ def submit_build(args):
 
     with open(join(path, '.binstar.yml')) as cfg:
         build_matrix = list(yaml.load_all(cfg))
-
+        if 'envvars' in build_matrix:
+            build_matrix['env'] = build_matrix.pop('envvars')
     builds = list(serialize_builds(build_matrix))
     log.info('Submitting %i sub builds' % len(builds))
     for i, build in enumerate(builds):

--- a/binstar_build_client/build_commands/_build.py
+++ b/binstar_build_client/build_commands/_build.py
@@ -146,8 +146,9 @@ def submit_build(args):
 
     with open(join(path, '.binstar.yml')) as cfg:
         build_matrix = list(yaml.load_all(cfg))
-        if 'envvars' in build_matrix:
-            build_matrix['env'] = build_matrix.pop('envvars')
+        for build in build_matrix:
+            if 'envvars' in build:
+                build['env'] = build.pop('envvars')
     builds = list(serialize_builds(build_matrix))
     log.info('Submitting %i sub builds' % len(builds))
     for i, build in enumerate(builds):

--- a/binstar_build_client/build_commands/_build.py
+++ b/binstar_build_client/build_commands/_build.py
@@ -34,7 +34,7 @@ from itertools import product
 from binstar_client import errors
 import argparse
 from binstar_client.utils.build_file import initial_build_config
-from binstar_build_client.utils.matrix as load_all_binstar_yml
+from binstar_build_client.utils.matrix import load_all_binstar_yml
 import sys
 
 from six.moves import input

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -15,7 +15,7 @@ from __future__ import (print_function, unicode_literals, division,
 
 from argparse import RawDescriptionHelpFormatter
 from contextlib import contextmanager
-import logging, yaml
+import logging
 import os
 from os.path import abspath, join, isfile
 import tarfile
@@ -183,8 +183,6 @@ def main(args):
                 package_name = build.get('package')
             if build.get('user'):
                 user_name = build.get('user')
-            if build.get('envvars'):
-                build['env'] = build.pop('envvars')
 
         # Force package to exist
         if args.package:

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -52,7 +52,8 @@ def submit_build(binstar, args):
 
     with open(join(path, '.binstar.yml')) as cfg:
         build_matrix = list(yaml.load_all(cfg))
-
+        if 'envvars' in build_matrix:
+            build_matrix['env'] = build_matrix.pop('envvars')
     builds = list(serialize_builds(build_matrix))
 
     if args.platform:
@@ -65,9 +66,7 @@ def submit_build(binstar, args):
         if args.platform:
             msg += " for platform %s" % args.platform
         raise errors.BinstarError(msg)
-    for build in builds:
-        if build.get('envvars'):
-            build['env'] = build['envvars']
+
     log.info('Submitting %i sub builds' % len(builds))
     for i, build in enumerate(builds):
         log.info(' %i)' % i + ' %(platform)-10s  %(engine)-15s  %(env)-15s' % build)

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -52,8 +52,9 @@ def submit_build(binstar, args):
 
     with open(join(path, '.binstar.yml')) as cfg:
         build_matrix = list(yaml.load_all(cfg))
-        if 'envvars' in build_matrix:
-            build_matrix['env'] = build_matrix.pop('envvars')
+        for build in build_matrix:
+            if 'envvars' in build:
+                build['env'] = build.pop('envvars')
     builds = list(serialize_builds(build_matrix))
 
     if args.platform:

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -186,6 +186,8 @@ def main(args):
                     package_name = build.get('package')
                 if build.get('user'):
                     user_name = build.get('user')
+                if build.get('envvars'):
+                    build['env'] = build.pop('envvars')
 
         # Force package to exist
         if args.package:

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -25,7 +25,7 @@ from binstar_build_client import BinstarBuildAPI
 from binstar_build_client.utils.filter import ExcludeGit
 from binstar_build_client.utils.git_utils import is_url, get_urlpath, \
     get_gitrepo
-from binstar_build_client.utils.matrix import serialize_builds
+from binstar_build_client.utils.matrix import serialize_builds, load_all_binstar_yml
 from binstar_client import errors
 from binstar_client.errors import UserError
 from binstar_client.utils import get_binstar, PackageSpec, upload_print_callback
@@ -50,11 +50,7 @@ def submit_build(binstar, args):
 
     log.info('Getting build product: %s' % abspath(args.path))
 
-    with open(join(path, '.binstar.yml')) as cfg:
-        build_matrix = list(yaml.load_all(cfg))
-        for build in build_matrix:
-            if 'envvars' in build:
-                build['env'] = build.pop('envvars')
+    build_matrix = load_all_binstar_yml(path)
     builds = list(serialize_builds(build_matrix))
 
     if args.platform:
@@ -181,14 +177,14 @@ def main(args):
 
         package_name = None
         user_name = None
-        with open(binstar_yml) as cfg:
-            for build in yaml.load_all(cfg):
-                if build.get('package'):
-                    package_name = build.get('package')
-                if build.get('user'):
-                    user_name = build.get('user')
-                if build.get('envvars'):
-                    build['env'] = build.pop('envvars')
+        build_matrix = load_all_binstar_yml(args.path)
+        for build in build_matrix:
+            if build.get('package'):
+                package_name = build.get('package')
+            if build.get('user'):
+                user_name = build.get('user')
+            if build.get('envvars'):
+                build['env'] = build.pop('envvars')
 
         # Force package to exist
         if args.package:

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -3,7 +3,7 @@ Build command
 
 Submit a build from your local path or  via a git url:
 
-See also: 
+See also:
 
   * [Submit A Build](http://docs.anaconda.org/build.html#SubmitABuild)
   * [Submit A Build From Github](http://docs.anaconda.org/build.html#GithubBuilds)
@@ -65,7 +65,9 @@ def submit_build(binstar, args):
         if args.platform:
             msg += " for platform %s" % args.platform
         raise errors.BinstarError(msg)
-
+    for build in builds:
+        if build.get('envvars'):
+            build['env'] = build['envvars']
     log.info('Submitting %i sub builds' % len(builds))
     for i, build in enumerate(builds):
         log.info(' %i)' % i + ' %(platform)-10s  %(engine)-15s  %(env)-15s' % build)
@@ -136,6 +138,9 @@ def submit_git_build(binstar, args):
     if not args.dry_run:
         log.info("Submitting the following repo for package creation: %s" % args.git_url)
         builds = get_gitrepo(urlparse(args.path))
+        for build in builds:
+            if build.get('envvars'):
+                build['env'] = build['envvars']
         # TODO: change channels= to labels=
         build = binstar.submit_for_url_build(args.package.user, args.package.name, builds,
                                              channels=args.labels, queue=args.queue, sub_dir=args.sub_dir,

--- a/binstar_build_client/utils/build_file.py
+++ b/binstar_build_client/utils/build_file.py
@@ -24,7 +24,7 @@ package: %(PACKAGE_NAME)s
 #===============================================================================
 # Build Matrix Options
 # These options may be a single item, a list or empty
-# The resulting number of builds is [platform * engine * env]
+# The resulting number of builds is [platform * engine * envvars]
 #===============================================================================
 
 ## The platforms to build on.
@@ -36,8 +36,8 @@ package: %(PACKAGE_NAME)s
 # engine:
 #  - python=2
 #  - python=3
-## The env param is an environment variable list
-# env:
+## The envvars param is an environment variable list
+# envvars:
 #  - MY_ENV=A CC=gcc
 #  - MY_ENV=B
 

--- a/binstar_build_client/utils/matrix.py
+++ b/binstar_build_client/utils/matrix.py
@@ -9,6 +9,7 @@ from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 
 from itertools import product
+import os
 import yaml
 
 def expand_build_matrix(instruction_set):
@@ -16,7 +17,7 @@ def expand_build_matrix(instruction_set):
 
     platforms = instruction_set.pop('platform', ['linux-64']) or [None]
     if not isinstance(platforms, list): platforms = [platforms]
-    envs = instruction_set.pop('envvars', instruction_set.pop('env', [None])) or [None]
+    envs = instruction_set.pop('env', [None]) or [None]
     if not isinstance(envs, list): envs = [envs]
     engines = instruction_set.pop('engine', ['python=2']) or [None]
     if not isinstance(engines, list): engines = [engines]
@@ -40,7 +41,7 @@ def serialize_builds(instruction_sets):
 
 
 def load_all_binstar_yml(path):
-    with open(join(path, '.binstar.yml')) as cfg:
+    with open(os.path.join(path, '.binstar.yml')) as cfg:
         build_matrix = list(yaml.load_all(cfg))
         for build in build_matrix:
             if 'envvars' in build:

--- a/binstar_build_client/utils/matrix.py
+++ b/binstar_build_client/utils/matrix.py
@@ -15,7 +15,7 @@ def expand_build_matrix(instruction_set):
 
     platforms = instruction_set.pop('platform', ['linux-64']) or [None]
     if not isinstance(platforms, list): platforms = [platforms]
-    envs = instruction_set.pop('env', [None]) or [None]
+    envs = instruction_set.pop('envvars', instruction_set.pop('env', [None])) or [None]
     if not isinstance(envs, list): envs = [envs]
     engines = instruction_set.pop('engine', ['python=2']) or [None]
     if not isinstance(engines, list): engines = [engines]

--- a/binstar_build_client/utils/matrix.py
+++ b/binstar_build_client/utils/matrix.py
@@ -9,6 +9,7 @@ from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 
 from itertools import product
+import yaml
 
 def expand_build_matrix(instruction_set):
     instruction_set = instruction_set.copy()
@@ -36,3 +37,12 @@ def serialize_builds(instruction_sets):
     for k, value in sorted(builds.items()):
         if value.get('exclude'): continue
         yield value
+
+
+def load_all_binstar_yml(path):
+    with open(join(path, '.binstar.yml')) as cfg:
+        build_matrix = list(yaml.load_all(cfg))
+        for build in build_matrix:
+            if 'envvars' in build:
+                build['env'] = build.pop('envvars')
+    return build_matrix

--- a/binstar_build_client/worker/tests/test_build_script.py
+++ b/binstar_build_client/worker/tests/test_build_script.py
@@ -249,6 +249,21 @@ class Test(unittest.TestCase):
             self.assertTrue(has_numpy)
             self.assertEqual(conda_npy, conda_npy_read)
 
+    def test_env_envvars(self):
+        'Test env or envvars can be used in .binstar.yml'
+        build_data = default_build_data()
+        for name in ('env', 'envvars'):
+            build_data['build_item_info'][name] = {'ENVIRONMENT_VARIABLE': '1'}
+            script_filename = gen_build_script(tempfile.mkdtemp(),
+                                                 build_data,
+                                                 ignore_setup_build=True,
+                                                 ignore_fetch_build_source=True)
+            self.addCleanup(os.unlink, script_filename)
+            contents = open(script_filename).read()
+            self.assertIn('ENVIRONMENT_VARIABLE=', contents)
+            build_data['build_item_info'].pop(name)
+
+
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.test_timeout']
     unittest.main()

--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -146,7 +146,7 @@ def create_exports(build_data, working_dir):
            }
 
 
-    build_env = build_item.get('env')
+    build_env = build_item.get('envvars', build_item.get('env'))
     if isinstance(build_env, (str, unicode)):
         _build_env = {}
         for item in shlex.split(build_env):

--- a/binstar_build_client/worker/worker.py
+++ b/binstar_build_client/worker/worker.py
@@ -81,6 +81,7 @@ class Worker(object):
                 job_data = bs.pop_build_job(self.config.username,
                                             self.config.queue,
                                             self.worker_id)
+
             except errors.NotFound:
                 self.write_status(False, "worker not found")
                 if self.args.show_traceback:
@@ -201,7 +202,8 @@ class Worker(object):
         Run a single build
         """
         job_id = job_data['job']['_id']
-
+        if 'envvars' in job_data['job']:
+            job_data['job']['env'] = job_data.pop('envvars')
         working_dir = self.working_dir(job_data)
 
         log.info("Removing previous build dir: {0}".format(working_dir))


### PR DESCRIPTION
Fixes #135 in a better way.  Changes `envvars` to `env` if `envvars` is in the .binstar.yml

[This small anaconda-server PR](https://github.com/Anaconda-Server/anaconda-server/pull/1685) is also needed in order for CI builds to use `envvars`

Best strategy is I think to merge this build PR which is indifferent to `env` or `envvars`.  Then merge the anaconda-server PR, then publicize the usage of `envvars`.