### PR TITLE
get rid of binstar user mention in favor of anaconda user

### DIFF
--- a/docker/linux-64/Dockerfile
+++ b/docker/linux-64/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH /opt/miniconda/bin:$PATH
 RUN conda config --set always_yes true && \
     conda config --set binstar_upload false && \
     conda config --add channels binstar
-RUN conda install conda-build jinja2 anaconda-client psutil binstar-build llvm
+RUN conda install conda-build jinja2 anaconda-client psutil anaconda-build llvm
 RUN anaconda config --set url https://api.anaconda.org
 USER root
 WORKDIR /root

--- a/docker/linux-64/Dockerfile
+++ b/docker/linux-64/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH /opt/miniconda/bin:$PATH
 RUN conda config --set always_yes true && \
     conda config --set binstar_upload false && \
     conda config --add channels binstar
-RUN conda install conda-build jinja2 anaconda-client psutil anaconda-build llvm
+RUN conda install conda-build jinja2 anaconda-client psutil binstar-build llvm
 RUN anaconda config --set url https://api.anaconda.org
 USER root
 WORKDIR /root
@@ -36,6 +36,4 @@ RUN yum remove -y git && \
     echo "export PATH=\$PATH:/usr/local/git/bin" >> /etc/bashrc && \
     ln -s /usr/local/git/bin/git /usr/bin/git
 
-USER binstar
-WORKDIR /home/binstar
 


### PR DESCRIPTION
At some point the username in the Dockerfile had changed from binstar to anaconda.  There was a leftover mention of binstar as a user in the Dockerfile that was causing errors in 4 or 5 docker related unittests if docker pull had been run beforehand to pull down the image I built yesterday.