### PR TITLE
prevent queues and workers from having bad chars in names

### DIFF
--- a/binstar_build_client/build_commands/queue.py
+++ b/binstar_build_client/build_commands/queue.py
@@ -4,6 +4,7 @@ Build Queue
 from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 from binstar_client.utils import get_binstar, bool_input
+from binstar_build_client.utils.validate_name import validate_name
 from binstar_build_client import BinstarBuildAPI
 from argparse import RawDescriptionHelpFormatter
 from dateutil.parser import parse as parse_date
@@ -56,6 +57,7 @@ def main(args):
 
         if queue_name is None:
             raise errors.BinstarError("Must specify a queue name to create")
+        validate_name(queue_name, 'queue')
         bs.add_build_queue(username, queue_name)
         print("Created queue %s" % queue_name)
         return

--- a/binstar_build_client/build_commands/queue.py
+++ b/binstar_build_client/build_commands/queue.py
@@ -4,7 +4,7 @@ Build Queue
 from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 from binstar_client.utils import get_binstar, bool_input
-from binstar_build_client.utils.validate_name import validate_name
+from binstar_build_client.utils.validate_name import is_valid_name
 from binstar_build_client import BinstarBuildAPI
 from argparse import RawDescriptionHelpFormatter
 from dateutil.parser import parse as parse_date
@@ -57,7 +57,12 @@ def main(args):
 
         if queue_name is None:
             raise errors.BinstarError("Must specify a queue name to create")
-        validate_name(queue_name, 'queue')
+        if not is_valid_name(queue_name):
+            raise errors.BinstarError('Invalid name for '
+                                      'queue: {}.  Must start'
+                                      ' with a letter and contain'
+                                      ' only numbers, letters, -, and _'.format(queue_name))
+
         bs.add_build_queue(username, queue_name)
         print("Created queue %s" % queue_name)
         return

--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -58,6 +58,26 @@ class Test(CLITestCase):
         self.assertEqual(deregister.call_count, 1)
 
     @urlpatch
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.register')
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.deregister')
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.load')
+    def test_register_name(self, load, deregister, urls, register):
+
+        main(['register', 'username/queue-1', '--name', 'myworker'], False)
+        self.assertEqual(register.call_count, 1)
+
+        main(['deregister', 'myworker'], False)
+        self.assertEqual(deregister.call_count, 1)
+
+    @urlpatch
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.register')
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.deregister')
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.load')
+    def test_register_bad_name(self, load, deregister, urls, register):
+        with self.assertRaises(errors.BinstarError):
+            main(['register', 'username/queue-1', '--name','!bad-name'], False)
+
+    @urlpatch
     @patch('binstar_build_client.worker.worker.Worker.work_forever')
     @patch('binstar_build_client.worker.register.WorkerConfiguration.load')
     @patch('binstar_build_client.worker.worker.Worker.run')

--- a/binstar_build_client/utils/validate_name.py
+++ b/binstar_build_client/utils/validate_name.py
@@ -1,0 +1,15 @@
+import re
+
+from binstar_client import errors
+
+base_pattern = '^[a-zA-Z{}\-_0-9]+$'
+
+def validate_name(n, context, allow_non_letters=''):
+    if not allow_non_letters:
+        allow_non_letters = ''
+    pat = re.compile(base_pattern.format("".join(allow_non_letters)))
+    if re.search(pat, n) is not None:
+        pass
+    else:
+        raise errors.BinstarError('Invalid name for '
+                                  '{}: {}'.format(context, n))

--- a/binstar_build_client/utils/validate_name.py
+++ b/binstar_build_client/utils/validate_name.py
@@ -4,12 +4,27 @@ from binstar_client import errors
 
 base_pattern = '^[a-zA-Z{}\-_0-9]+$'
 
-def validate_name(n, context, allow_non_letters=''):
+def validate_name(name, context, allow_non_letters=''):
+    '''validate_name(name, context, allow_non_letters='')
+    Used to reject queue names like
+
+    orgname/queue!
+    orgname/que#e1
+
+    Params:
+        name: the name to validate
+        context: a context string for error messages if invalid
+        allow_non_letters: iterable of characters
+
+    raises BinstarError if name does not match regex
+    of all letters / numbers, dash, underscore, plus the letters
+    included in allow_non_letters.
+    '''
     if not allow_non_letters:
         allow_non_letters = ''
     pat = re.compile(base_pattern.format("".join(allow_non_letters)))
-    if re.search(pat, n) is not None:
+    if re.search(pat, name) is not None:
         pass
     else:
         raise errors.BinstarError('Invalid name for '
-                                  '{}: {}'.format(context, n))
+                                  '{}: {}'.format(context, name))

--- a/binstar_build_client/utils/validate_name.py
+++ b/binstar_build_client/utils/validate_name.py
@@ -5,7 +5,7 @@ from binstar_client import errors
 PATTERN = '^[a-zA-Z]+[a-zA-Z\-_0-9]*$'
 
 def is_valid_name(name):
-    '''is_valid_name(name, context, allow_non_letters='')
+    '''is_valid_name(name)
     Used to reject queue names like
 
     orgname/queue!

--- a/binstar_build_client/utils/validate_name.py
+++ b/binstar_build_client/utils/validate_name.py
@@ -16,7 +16,4 @@ def is_valid_name(name):
         name: the name to validate
 
     '''
-    if re.search(PATTERN, name) is not None:
-        return True
-    else:
-        return False
+    return bool(re.search(PATTERN, name))

--- a/binstar_build_client/utils/validate_name.py
+++ b/binstar_build_client/utils/validate_name.py
@@ -2,29 +2,21 @@ import re
 
 from binstar_client import errors
 
-base_pattern = '^[a-zA-Z{}\-_0-9]+$'
+PATTERN = '^[a-zA-Z]+[a-zA-Z\-_0-9]*$'
 
-def validate_name(name, context, allow_non_letters=''):
-    '''validate_name(name, context, allow_non_letters='')
+def is_valid_name(name):
+    '''is_valid_name(name, context, allow_non_letters='')
     Used to reject queue names like
 
     orgname/queue!
     orgname/que#e1
+    orgname/_
 
     Params:
         name: the name to validate
-        context: a context string for error messages if invalid
-        allow_non_letters: iterable of characters
 
-    raises BinstarError if name does not match regex
-    of all letters / numbers, dash, underscore, plus the letters
-    included in allow_non_letters.
     '''
-    if not allow_non_letters:
-        allow_non_letters = ''
-    pat = re.compile(base_pattern.format("".join(allow_non_letters)))
-    if re.search(pat, name) is not None:
-        pass
+    if re.search(PATTERN, name) is not None:
+        return True
     else:
-        raise errors.BinstarError('Invalid name for '
-                                  '{}: {}'.format(context, name))
+        return False

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -11,10 +11,11 @@ import logging
 
 from binstar_client import errors
 from binstar_client.utils import get_binstar
-
+from binstar_build_client.utils.validate_name import validate_name
 from binstar_build_client import BinstarBuildAPI
 from binstar_build_client.worker.register import (WorkerConfiguration,
                                                   split_queue_arg)
+
 
 OS_MAP = {'darwin': 'osx', 'windows':'win'}
 ARCH_MAP = {'x86': '32',
@@ -52,6 +53,8 @@ def main(args):
     args.username, args.queue = split_queue_arg(args.queue)
     bs = get_binstar(args, cls=BinstarBuildAPI)
 
+    if args.name:
+        validate_name(args.name, 'worker name')
     worker_config = WorkerConfiguration.register(
         bs, args.username, args.queue,
         args.platform, args.hostname, args.dist,

--- a/binstar_build_client/worker_commands/register.py
+++ b/binstar_build_client/worker_commands/register.py
@@ -11,7 +11,7 @@ import logging
 
 from binstar_client import errors
 from binstar_client.utils import get_binstar
-from binstar_build_client.utils.validate_name import validate_name
+from binstar_build_client.utils.validate_name import is_valid_name
 from binstar_build_client import BinstarBuildAPI
 from binstar_build_client.worker.register import (WorkerConfiguration,
                                                   split_queue_arg)
@@ -54,7 +54,12 @@ def main(args):
     bs = get_binstar(args, cls=BinstarBuildAPI)
 
     if args.name:
-        validate_name(args.name, 'worker name')
+        if not is_valid_name(args.name):
+            raise errors.BinstarError('Invalid name for '
+                                  'worker: {}.  Must start'
+                                  ' with a letter and contain'
+                                  ' only numbers, letters, -, and _'.format(args.name))
+
     worker_config = WorkerConfiguration.register(
         bs, args.username, args.queue,
         args.platform, args.hostname, args.dist,


### PR DESCRIPTION
Simple regex to avoid bad characters in queue or worker names when doing the following commands:

```
anaconda build queue -c psteinberg/some_name
```
```
anaconda worker register psteinberg/abc --name some_name
```