### PR TITLE
Fix/unique worker names

### DIFF
--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -16,6 +16,7 @@ from binstar_client.tests.fixture import CLITestCase
 from binstar_client.tests.urlmock import urlpatch
 from binstar_build_client.scripts.worker import main
 from binstar_build_client.worker.register import WorkerConfiguration
+from binstar_build_client import worker
 from glob import glob
 from binstar_client import errors
 
@@ -49,13 +50,33 @@ class Test(CLITestCase):
     @patch('binstar_build_client.worker.register.WorkerConfiguration.register')
     @patch('binstar_build_client.worker.register.WorkerConfiguration.deregister')
     @patch('binstar_build_client.worker.register.WorkerConfiguration.load')
-    def test_register(self, load, deregister, urls, register):
+    def test_register(self, load, deregister, register, urls):
 
         main(['register', 'username/queue-1'], False)
-        self.assertEqual(register.call_count, 1)
+        self.assertEqual(urls.call_count, 1)
 
         main(['deregister', 'worker_id'], False)
         self.assertEqual(deregister.call_count, 1)
+
+    @urlpatch
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.load')
+    def test_register_duplicate_name(self, load, urls):
+        registered = {}
+        @classmethod
+        def register_func(cls, *args, **kwargs):
+            name = kwargs.get('name')
+            if name in registered:
+                raise errors.BinstarError('already registered {}'.format(registered))
+            registered[name] = True
+            args2 = [name] + list(args)
+            return WorkerConfiguration(*args2)
+
+        with patch.object(worker.register.WorkerConfiguration, 'register', new=register_func) as register:
+            main(['register', 'username/queue-1', '--name', 'worker1'], False)
+            self.assertEqual(registered, {'worker1': True})
+            with self.assertRaises(errors.BinstarError):
+                main(['register', 'username/queue-1', '--name', 'worker1'], False)
+
 
     @urlpatch
     @patch('binstar_build_client.worker.worker.Worker.work_forever')

--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -7,18 +7,22 @@ Created on Feb 18, 2014
 from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 
+from argparse import Namespace
+from glob import glob
 import os
 import yaml
-from mock import patch, Mock
+from mock import patch, Mock, MagicMock
 import unittest
+
+from binstar_client import errors
+from binstar_client.utils import get_binstar
 
 from binstar_client.tests.fixture import CLITestCase
 from binstar_client.tests.urlmock import urlpatch
 from binstar_build_client.scripts.worker import main
 from binstar_build_client.worker.register import WorkerConfiguration
 from binstar_build_client import worker
-from glob import glob
-from binstar_client import errors
+from binstar_build_client import BinstarBuildAPI
 
 test_workers = os.path.abspath('./test-workers')
 worker_data = {
@@ -82,7 +86,8 @@ class Test(CLITestCase):
     @patch('binstar_build_client.worker.worker.Worker.work_forever')
     @patch('binstar_build_client.worker.register.WorkerConfiguration.load')
     @patch('binstar_build_client.worker.worker.Worker.run')
-    def test_worker_simple(self, run, load, loop, urls):
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.validate_worker_name')
+    def test_worker_simple(self, validate, run, load, loop, urls):
 
         main(['--show-traceback', 'worker', 'run', worker_data['worker_id']], False)
 
@@ -95,13 +100,31 @@ class Test(CLITestCase):
     @patch('binstar_build_client.worker_commands.docker_run.docker')
     @patch('binstar_build_client.worker.docker_worker.docker')
     @patch('binstar_build_client.worker.docker_worker.kwargs_from_env')
-    def test_worker_simple_docker(self, kwargs_from_env, docker1, docker2, run, load, loop, urls):
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.validate_worker_name')
+    def test_worker_simple_docker(self, validate, kwargs_from_env, docker1, docker2, run, load, loop, urls):
 
         docker1.Client = docker2.Client = Mock()
 
         main(['--show-traceback', 'worker', 'docker_run', worker_data['worker_id']], False)
 
         self.assertEqual(loop.call_count, 1)
+
+    @patch('binstar_build_client.worker.register.WorkerConfiguration.registered_workers')
+    def test_duplicate_worker_name(self, registered):
+        worker_configs = [Namespace(name='abc',
+                          worker_id='id_' + worker,
+                          username='user',
+                          queue='queue',
+                          platform='platform',
+                          hostname='hostname',
+                          dist='dist')  for worker in ('a', 'b')]
+
+        for worker_config in worker_configs:
+            worker_config.to_dict = lambda : worker_config.__dict__
+        registered.return_value = iter(worker_configs)
+        bs = get_binstar(Namespace(), cls=BinstarBuildAPI)
+        with self.assertRaises(errors.BinstarError):
+            WorkerConfiguration.validate_worker_name(bs, 'abc')
 
     def test_register_backwards_compat(self):
 

--- a/binstar_build_client/worker/register.py
+++ b/binstar_build_client/worker/register.py
@@ -92,17 +92,16 @@ class WorkerConfiguration(object):
 
     @classmethod
     def validate_worker_name(cls, bs, name):
-        worker_name_to_id = {}
+        workers_by_name = {}
         for worker in cls.registered_workers(bs):
-            if not worker.name in worker_name_to_id:
-                worker_name_to_id[worker.name] = [worker]
+            if not worker.name in workers_by_name:
+                workers_by_name[worker.name] = [worker]
             else:
-                worker_name_to_id[worker.name].append(worker)
-        worker_name_to_id = {k:v for k,v in worker_name_to_id.items() if len(v) > 1}
-
-        if name in worker_name_to_id:
+                workers_by_name[worker.name].append(worker)
+        workers = workers_by_name.get(name, [])
+        if len(workers) > 1:
             msg = ''
-            for worker in worker_name_to_id[name]:
+            for worker in workers:
                 worker.name = name
                 msg += '{name}, id:{worker_id}, hostname:{hostname}, queue:{username}/{queue}\n'.format(**worker.to_dict())
             raise errors.BinstarError('Cannot anaconda worker run {}'

--- a/binstar_build_client/worker/tests/test_worker_config.py
+++ b/binstar_build_client/worker/tests/test_worker_config.py
@@ -37,6 +37,7 @@ class Test(unittest.TestCase):
 \tpid: None
 \tdist: dist
 \thostname: hostname
+\tname: worker_name
 \tplatform: platform
 \tqueue: queue
 \tusername: username

--- a/binstar_build_client/worker_commands/docker_run.py
+++ b/binstar_build_client/worker_commands/docker_run.py
@@ -13,6 +13,7 @@ from binstar_client.utils import get_binstar
 from binstar_build_client import BinstarBuildAPI
 from binstar_build_client.worker.docker_worker import DockerWorker
 from binstar_build_client.worker_commands.run import add_parser as add_worker_parser
+from binstar_build_client.worker_commands.run import WRONG_HOSTNAME_MSG
 from binstar_build_client.worker.register import WorkerConfiguration
 
 try:
@@ -28,9 +29,12 @@ def main(args):
         raise errors.UserError("anaconda worker docker_run requires docker and docker-py to be installed\n"
                                "Run:\n\tpip install docker-py")
 
-
     bs = get_binstar(args, cls=BinstarBuildAPI)
     worker_config = WorkerConfiguration.load(args.worker_id, bs, warn=True)
+    WorkerConfiguration.validate_worker_name(bs, args.worker_id)
+    if worker_config.hostname != WorkerConfiguration.HOSTNAME:
+        log.warn(WRONG_HOSTNAME_MSG.format(worker_config.hostname,
+                                           WorkerConfiguration.HOSTNAME))
     worker = DockerWorker(bs, worker_config, args)
     worker.work_forever()
 

--- a/binstar_build_client/worker_commands/docker_run.py
+++ b/binstar_build_client/worker_commands/docker_run.py
@@ -30,7 +30,7 @@ def main(args):
 
 
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    worker_config = WorkerConfiguration.load(args.worker_id, bs)
+    worker_config = WorkerConfiguration.load(args.worker_id, bs, warn=True)
     worker = DockerWorker(bs, worker_config, args)
     worker.work_forever()
 

--- a/binstar_build_client/worker_commands/list.py
+++ b/binstar_build_client/worker_commands/list.py
@@ -6,11 +6,13 @@ anaconda worker list
 from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 
+import logging
+
 from binstar_build_client.worker.register import WorkerConfiguration
 from binstar_client.utils import get_binstar
 from binstar_build_client import BinstarBuildAPI
+from binstar_build_client.worker.register import split_queue_arg
 
-import logging
 log = logging.getLogger('binstar.build')
 
 def print_registered_workers(bs, args):
@@ -18,16 +20,17 @@ def print_registered_workers(bs, args):
     has_workers = False
 
     log.info('Registered workers:')
-
+    if args.queue:
+        user, args.queue = split_queue_arg(args.queue)
     for wconfig in WorkerConfiguration.registered_workers(bs):
         has_workers = True
         if args.this_host_only and wconfig.hostname != WorkerConfiguration.HOSTNAME:
             continue
-        if args.queue and args.queue != wconfig:
+        if args.queue and args.queue != wconfig.queue:
             continue
         if args.org and args.org != wconfig.username:
             continue
-        msg = '{name}, id:{worker_id}, hostname:{hostname}, queue:{username}/{queue}'.format(name=wconfig.name, **wconfig.to_dict())
+        msg = '{name}, id:{worker_id}, hostname:{hostname}, queue:{username}/{queue}'.format(**wconfig.to_dict())
         if wconfig.pid:
             msg += ' (running with pid: {})'.format(wconfig.pid)
 
@@ -39,7 +42,7 @@ def print_registered_workers(bs, args):
 def main(args):
 
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    print_registered_workers(bs, this_host_only=args.this_host_only)
+    print_registered_workers(bs, args)
 
 def add_parser(subparsers, name='list',
                description='List build workers and queues',
@@ -50,6 +53,7 @@ def add_parser(subparsers, name='list',
                                    )
     parser.add_argument('--this-host-only',
                         '-t',
+                        action='store_true',
                         help="Print only workers registered from this hostname.")
     parser.add_argument('--org',
                         '-o',

--- a/binstar_build_client/worker_commands/run.py
+++ b/binstar_build_client/worker_commands/run.py
@@ -21,7 +21,7 @@ log = logging.getLogger('binstar.build')
 
 def main(args):
     bs = get_binstar(args, cls=BinstarBuildAPI)
-    worker_config = WorkerConfiguration.load(args.worker_id, bs)
+    worker_config = WorkerConfiguration.load(args.worker_id, bs, warn=True)
     args.conda_build_dir = args.conda_build_dir.format(platform=worker_config.platform)
     log.info("Using conda build directory: {}".format(args.conda_build_dir))
     log.info(str(worker_config))

--- a/binstar_build_client/worker_commands/run.py
+++ b/binstar_build_client/worker_commands/run.py
@@ -18,10 +18,18 @@ from binstar_build_client.worker.register import WorkerConfiguration
 
 log = logging.getLogger('binstar.build')
 
+WRONG_HOSTNAME_MSG = 'Proceeding with worker id registered for ' + \
+                     'different hostname: {}. ' + \
+                     'This host is: {}.'
+
 
 def main(args):
     bs = get_binstar(args, cls=BinstarBuildAPI)
     worker_config = WorkerConfiguration.load(args.worker_id, bs, warn=True)
+    WorkerConfiguration.validate_worker_name(bs, args.worker_id)
+    if worker_config.hostname != WorkerConfiguration.HOSTNAME:
+        log.warn(WRONG_HOSTNAME_MSG.format(worker_config.hostname,
+                                           WorkerConfiguration.HOSTNAME))
     args.conda_build_dir = args.conda_build_dir.format(platform=worker_config.platform)
     log.info("Using conda build directory: {}".format(args.conda_build_dir))
     log.info(str(worker_config))


### PR DESCRIPTION
Fixes #222 .

The `anaconda worker list` still filters based on hostname but you are allowed to run a worker without a matching hostname (warning arises then).  Prevents duplicate worker names rather than just preventing duplicate names within one hostname as it was done before.