### PR TITLE
Use BINSTAR_API_SITE as target for uploading

### DIFF
--- a/binstar_build_client/worker/utils/data/build_script.bat
+++ b/binstar_build_client/worker/utils/data/build_script.bat
@@ -204,6 +204,13 @@ goto:eof
     {% endfor %}
     conda config --file "%CONDARC%" --set binstar_upload no --set always_yes yes --set show_channel_urls yes
 
+    echo "set BINSTAR_CONFIG_DIR=%WORKING_DIR%\binstar"
+    set "BINSTAR_CONFIG_DIR=%WORKING_DIR%\binstar"
+    echo "mkdir %BINSTAR_CONFIG_DIR%"
+    mkdir "%BINSTAR_CONFIG_DIR%"
+    echo "anaconda config --set url "%BINSTAR_API_SITE%"
+    anaconda config --set url "%BINSTAR_API_SITE%"
+
     call:bb_before_environment
     {{check_result()}}
 

--- a/binstar_build_client/worker/utils/data/build_script.sh
+++ b/binstar_build_client/worker/utils/data/build_script.sh
@@ -93,6 +93,12 @@ setup_build(){
                  --set always_yes yes \
                  --set show_channel_urls yes
 
+    echo "export BINSTAR_CONFIG_DIR=${WORKING_DIR}/binstar"
+    export BINSTAR_CONFIG_DIR="${WORKING_DIR}/binstar"
+    echo "mkdir ${BINSTAR_CONFIG_DIR}"
+    mkdir "${BINSTAR_CONFIG_DIR}"
+    echo "anaconda config --set url \"${BINSTAR_API_SITE}\""
+    anaconda config --set url "${BINSTAR_API_SITE}"
 
     bb_before_environment;
 


### PR DESCRIPTION
Uses the `BINSTAR_CONFIG_DIR` to create a local anaconda client configuration pointing to the `BINSTAR_API_SITE` defined in the build script.