### PR TITLE
Disable slow CONDA_NPY test

### DIFF
--- a/binstar_build_client/worker/tests/test_build_script.py
+++ b/binstar_build_client/worker/tests/test_build_script.py
@@ -220,6 +220,7 @@ class Test(unittest.TestCase):
         else:
             self.assertEqual(build_env_path, '"${WORKING_DIR}/env"')
 
+    @unittest.skip('This test is too slow')
     def test_conda_npy(self):
         build_data = default_build_data()
         build_data['build_item_info']['engine'] = 'numpy=1.9'


### PR DESCRIPTION
If you look at https://anaconda.org/binstar/binstar-build/builds/539/4#L1389, this test is responsible for all the recent windows Python 2.7 test failures. It is also extremely slow. Is there another way we could test this?