### PR TITLE
Ref/cmd line

### DIFF
--- a/binstar_build_client/scripts/build.py
+++ b/binstar_build_client/scripts/build.py
@@ -35,6 +35,10 @@ def add_parser(subparsers):
 
                                       )
 
+    parser.add_argument('-V', '--version',
+                        action='version',
+                        version='anaconda-build {}'.format(version))
+
     add_subparser_modules(parser, build_commands, 'conda_server_build.subcommand')
 
 

--- a/binstar_build_client/worker_commands/docker_run.py
+++ b/binstar_build_client/worker_commands/docker_run.py
@@ -9,6 +9,7 @@ import logging
 
 from binstar_client import errors
 from binstar_client.utils import get_binstar
+from clyent.logs import setup_logging
 
 from binstar_build_client import BinstarBuildAPI
 from binstar_build_client.worker.docker_worker import DockerWorker
@@ -35,6 +36,10 @@ def main(args):
     if worker_config.hostname != WorkerConfiguration.HOSTNAME:
         log.warn(WRONG_HOSTNAME_MSG.format(worker_config.hostname,
                                            WorkerConfiguration.HOSTNAME))
+
+    setup_logging(logging.getLogger('binstar_build_client'), args.log_level,
+                  args.color, show_tb=args.show_traceback)
+
     worker = DockerWorker(bs, worker_config, args)
     worker.work_forever()
 

--- a/binstar_build_client/worker_commands/run.py
+++ b/binstar_build_client/worker_commands/run.py
@@ -9,6 +9,7 @@ import logging
 import os
 import yaml
 
+from clyent.logs import setup_logging
 from binstar_client.utils import get_binstar
 
 from binstar_build_client import BinstarBuildAPI
@@ -31,6 +32,10 @@ def main(args):
         log.warn(WRONG_HOSTNAME_MSG.format(worker_config.hostname,
                                            WorkerConfiguration.HOSTNAME))
     args.conda_build_dir = args.conda_build_dir.format(platform=worker_config.platform)
+
+    setup_logging(logging.getLogger('binstar_build_client'), args.log_level,
+                  args.color, show_tb=args.show_traceback)
+
     log.info("Using conda build directory: {}".format(args.conda_build_dir))
     log.info(str(worker_config))
 


### PR DESCRIPTION
Adds a much-needed `--version` flag, and generates some better log output when the build worker is running.