### PR TITLE
fix misplaced check of envvars, fix github url pattern expression

### DIFF
--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -139,9 +139,6 @@ def submit_git_build(binstar, args):
     if not args.dry_run:
         log.info("Submitting the following repo for package creation: %s" % args.git_url)
         builds = get_gitrepo(urlparse(args.path))
-        for build in builds:
-            if build.get('envvars'):
-                build['env'] = build['envvars']
         # TODO: change channels= to labels=
         build = binstar.submit_for_url_build(args.package.user, args.package.name, builds,
                                              channels=args.labels, queue=args.queue, sub_dir=args.sub_dir,

--- a/binstar_build_client/build_commands/tests/test_build_commands.py
+++ b/binstar_build_client/build_commands/tests/test_build_commands.py
@@ -1,0 +1,54 @@
+'''
+test_build_commands.py includes tests for commands
+that start with:
+
+anaconda build
+'''
+from __future__ import (print_function, unicode_literals, division,
+    absolute_import)
+
+from argparse import Namespace
+from glob import glob
+import os
+import yaml
+from mock import patch, Mock, MagicMock
+import unittest
+
+from binstar_client import errors
+from binstar_client.utils import get_binstar
+
+from binstar_client.tests.fixture import CLITestCase
+from binstar_client.tests.urlmock import urlpatch
+from binstar_build_client.scripts.build import main
+from binstar_build_client.worker.register import WorkerConfiguration
+from binstar_build_client import worker
+from binstar_build_client import BinstarBuildAPI
+
+class Test(CLITestCase):
+    @urlpatch
+    #@patch('binstar_client.commands.login.interactive_login')
+    #@patch('binstar_client.commands.login.interactive_get_token')
+    @patch('binstar_client.utils.get_binstar')
+    def _tst_submit_git_url(self, bs,  urls):#get_token, login,
+        bs.user = lambda: {}
+        args = ['submit', self.repo]
+        main(args, False)
+
+    def test_submit_git_url_ok(self):
+        self.repo = 'https://github.com/conda/conda-recipes'
+        self._tst_submit_git_url()
+
+    def test_submit_git_url_no_github(self):
+        self.repo = 'https://gitlab.com/conda/conda-recipes'
+        with self.assertRaises(errors.UserError):
+            self._tst_submit_git_url()
+
+    def test_submit_git_url_with_dot(self):
+        self.repo = 'http://github.com/PeterDSteinberg/myorg.package1'
+        self._tst_submit_git_url()
+
+    def test_submit_git_url_dots_in_branch(self):
+        self.repo = 'https://github.com/PeterDSteinberg/myorg.package1/tree/mybranch.odd.name'
+        self._tst_submit_git_url()
+if __name__ == '__main__':
+    unittest.main()

--- a/binstar_build_client/utils/git_utils.py
+++ b/binstar_build_client/utils/git_utils.py
@@ -52,7 +52,7 @@ def get_gitrepo(url):
     if url.netloc != 'github.com':
         raise errors.UserError("Currently only github.com urls are supported (got %s)" % url.netloc)
 
-    pat = re.compile('^/(?P<repo>[\w-]+/[\w-]+)(/tree/(?P<branch>[\w/]+))?(.git)?$')
+    pat = re.compile('^/(?P<repo>[\w-]+/[-\w\.]+)(/tree/(?P<branch>[\w/\.]+))?(.git)?$')
     match = pat.match(url.path)
     if not match:
         raise errors.UserError("URL path '%s' is not a git repo" % url.path)


### PR DESCRIPTION
Fixes #241 where `anaconda build submit http://github.com/PeterDSteinberg/myorg.package1`  was failing because of `.` in package name.

Also fixes #242 where a bad placement of a check for `envvars` resulted in a AttributeError (did not have a .get attribute)

These two fixes are critical for 0.15.0 to get git urls working again with `anaconda build submit`