### PR TITLE
[PR] allow --tail / -f to automatically tail a submitted build

### DIFF
--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -175,10 +175,12 @@ def tail_sub_build(binstar, args, build_no):
         elif raise_:
             raise errors.BinstarError('Sub-build {}.{} for '
                                       'package {} does not exist'.format(build_no, sub_build_no, package))
+        else:
+            break
     return 0
 
 def clean_validate_tail_args(args):
-    tail_sub_builds = sorted(_.strip() for _ in args.tail)
+    tail_sub_builds = sorted(_.strip() for _ in args.tail) or ['all']
     for sub_build_no in tail_sub_builds:
         if sub_build_no == 'all':
             continue

--- a/binstar_build_client/build_commands/submit.py
+++ b/binstar_build_client/build_commands/submit.py
@@ -157,20 +157,17 @@ def submit_git_build(binstar, args):
 
 
 def tail_sub_build(binstar, args, build_no):
-    short_arg = '-f' if args.tail_lines is None else '-n'
     spacer = '###\n###'
     for sub_build_no, raise_ in args.sub_build_gen():
         if binstar.sub_build_exists(args.package.user, args.package.name, build_no, sub_build_no):
             build_no_sub_build_no = '{}.{}'.format(build_no, sub_build_no)
-            tail_args = Namespace(f=args.tail_lines is None,
-                                  n=args.tail_lines,
-                                  build_no=build_no_sub_build_no)
+            tail_args = Namespace(f=True,n=None)
             vars(tail_args).update(vars(args))
+            tail_args.build_no = build_no_sub_build_no
             log.info(spacer)
-            log.info('\t\tanaconda build tail {} {}/{} {}'.format(short_arg,
-                                                       args.package.user,
-                                                       args.package.name,
-                                                       build_no_sub_build_no))
+            log.info('\t\tanaconda build tail -f {}/{} {}'.format(args.package.user,
+                                                                  args.package.name,
+                                                                  build_no_sub_build_no))
             log.info(spacer)
             ret_val = tail_main(tail_args)
             if ret_val:
@@ -319,17 +316,11 @@ def add_parser(subparsers):
 
     tail_group = parser.add_argument_group('tail')
     tail_group.add_argument('--tail',
+                            '-f',
                             nargs="*",
                             dest='tail',
                             help="If '--tail all' or "
                                  "'--tail <sub-build-int> <sub-build-int>' "
                                  "\n\tthen immediately tail "
                                  "all sub-builds or given sub-build integers")
-    tail_group.add_argument('--tail-lines',
-                            type=int,
-                            help='Tail the top "--tail-lines <int>"'
-                                 'lines of each sub-build given '
-                                 'in --tail.\n\t  If --tail-lines is not given, '
-                                 'then wait on "anaconda build tail -f" '
-                                 'for each sub-build in order')
     parser.set_defaults(main=main)

--- a/binstar_build_client/mixins/build.py
+++ b/binstar_build_client/mixins/build.py
@@ -8,6 +8,7 @@ from __future__ import (print_function, unicode_literals, division,
     absolute_import)
 
 from binstar_client.utils import jencode, compute_hash
+from binstar_build_client.utils import get_anaconda_url
 from binstar_client.requests_ext import stream_multipart
 import requests
 from binstar_client.errors import BinstarError
@@ -155,4 +156,15 @@ class BuildMixin(object):
         self._check_response(res)
 
         return
+
+    def sub_build_exists(self, username, package, build_no, sub_build_no):
+        url = '/{}/{}/builds/{}.{}'.format(username,
+                                           package, build_no,
+                                           sub_build_no)
+        url = get_anaconda_url(self, url)
+        res = self.session.get(url)
+        import sys
+        print(url, res.status_code, file=sys.stderr)
+        if res.status_code in (200, 201):
+            return res
 

--- a/binstar_build_client/mixins/build.py
+++ b/binstar_build_client/mixins/build.py
@@ -163,8 +163,6 @@ class BuildMixin(object):
                                            sub_build_no)
         url = get_anaconda_url(self, url)
         res = self.session.get(url)
-        import sys
-        print(url, res.status_code, file=sys.stderr)
         if res.status_code in (200, 201):
             return res
 


### PR DESCRIPTION
Fixes issue #37 allowing automatic tailing of all or some build logs within a usage of `anaconda build submit`

Here is how the arguments are supposed to work:

 * `anaconda build submit ./ --queue psteinberg/abc --tail --platform osx-64` (submit the current directory then sequentially `anaconda build tail -f` for all sub-builds
 * `anaconda build submit ./ --queue psteinberg/abc --tail --sub-builds 0 1 --platform osx-64` (submit the current directory then `anaconda build tail -f` automatically for all sub-builds 0 and 1
 * replace `--tail` with `-f` in the commands above and it's the same thing

TODO:
 * [ ] update docs.anaconda.org
 * [ ] add tests
 * [ ] consider adding a timeout arg to `--tail` in the event that an attempt is made to `tail -f` a sub-build that is never started because of a down worker.  In those events currently, giving `--tail` or `-f` hangs indefinitely.  Thoughts?