### PR TITLE
add worker_stats func for info on memory, disk use, conda list/info/env

### DIFF
--- a/binstar_build_client/mixins/build_queue.py
+++ b/binstar_build_client/mixins/build_queue.py
@@ -6,6 +6,7 @@ from binstar_client import errors
 from binstar_client.utils import jencode
 import binstar_client
 import binstar_build_client
+from binstar_build_client.utils.worker_stats import worker_stats
 
 log = logging.getLogger('binstar.build')
 
@@ -158,3 +159,10 @@ class BuildQueueMixin(object):
 
         self._check_response(res, [200])
         return res.json().get('jobs', [])
+
+    def upload_worker_stats(self, username, queue_name, worker_id):
+        url = '%s/build-worker/%s/%s/%s/worker-stats' % (self.domain, username, queue_name, worker_id)
+        data, headers = jencode(worker_stats=worker_stats())
+        res = self.session.post(url, data=data, headers=headers)
+        self._check_response(res, [201])
+        return res.json()

--- a/binstar_build_client/tests/test_worker_script.py
+++ b/binstar_build_client/tests/test_worker_script.py
@@ -20,6 +20,7 @@ from binstar_client.utils import get_binstar
 from binstar_client.tests.fixture import CLITestCase
 from binstar_client.tests.urlmock import urlpatch
 from binstar_build_client.scripts.worker import main
+from binstar_build_client.utils.worker_stats import worker_stats
 from binstar_build_client.worker.register import WorkerConfiguration
 from binstar_build_client import worker
 from binstar_build_client import BinstarBuildAPI

--- a/binstar_build_client/utils/tests/test_worker_stats.py
+++ b/binstar_build_client/utils/tests/test_worker_stats.py
@@ -1,0 +1,25 @@
+import unittest
+import mock
+import os
+
+from binstar_build_client.utils.worker_stats import worker_stats
+
+expected_keys = {'win': set(('fsutil', 'systeminfo')),
+                 'posix': set(('df',('vm_stat', 'meminfo')))}
+
+class Test(unittest.TestCase):
+    def test_keys(self):
+        stats = worker_stats()
+        for key, value in stats.items():
+            if os.name == 'nt':
+                self.assertEqual(sorted(stats.keys()),
+                                 expected_keys['win'])
+            else:
+                self.assertIn('df', stats)
+                if 'vm_stat' in stats or 'meminfo' in stats:
+                    has_mem = True
+                else:
+                    has_mem = False
+                self.assertTrue(has_mem)
+            self.assertEqual(sorted(value.keys()), ['cmd', 'out'])
+


### PR DESCRIPTION
Adds a function called `worker_stats` that collects a dictionary of information about:
 * memory usage
 * disk usage
 * `conda list`
 * `conda env list`
 * `conda info`

Adds a function to the `build_queues.py` mixin to upload the stats dict to Repository.

TODO:
 * [ ] determine Repository UI look for this information and make a PR there
 * [ ] update docs.anaconda.org
 * [ ] revisit the testing of this -build PR when the anaconda-server PR is developed